### PR TITLE
Improve local environment guidance and test configuration

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -1,17 +1,54 @@
 # Local Development Configuration Example
-# Copy this to .env.local for local development
+# Copy this to .env.local and update the values for your environment.
+#
+# The defaults below keep the application running without any external services.
+# When you're ready to integrate Supabase + Google OAuth, switch to the section
+# at the bottom of this file.
 
-# Enable simple dev auth (no Supabase needed)
+# -------------------------------------------------------------
+# Quick start (no Supabase required)
+# -------------------------------------------------------------
+# Enables the built-in development auth flow so you can log in without
+# configuring Supabase. Leave this as "true" until you have Supabase ready.
 NEXT_PUBLIC_DEV_AUTH=true
 
-# Dummy values for required env vars (when using dev auth)
-NEXT_PUBLIC_SUPABASE_URL=https://dummy.supabase.co
-NEXT_PUBLIC_SUPABASE_ANON_KEY=dummy_anon_key
-SUPABASE_SERVICE_ROLE=dummy_service_role
+# Dummy Supabase values that satisfy runtime checks when dev auth is enabled.
+# These are safe placeholders and do not connect to a live database.
+NEXT_PUBLIC_SUPABASE_URL=https://example.supabase.co
+NEXT_PUBLIC_SUPABASE_ANON_KEY=dummy-anon-key
+SUPABASE_SERVICE_ROLE=dummy-service-role
 
-# CSRF Secret (required - generate a random 32 char string)
-CSRF_SECRET=your_32_character_random_string_here
+# Required security secrets – replace with your own values in .env.local.
+# Generate with:
+#   openssl rand -hex 16     -> CSRF_SECRET (32 hex characters)
+#   openssl rand -base64 32  -> ENCRYPTION_KEY (44 char base64 string)
+CSRF_SECRET=replace-with-32-char-hex
+ENCRYPTION_KEY=replace-with-44-char-base64
 
-# Optional: Add your AI API keys for testing
-# OPENAI_API_KEY=sk-your_key_here
-# ANTHROPIC_API_KEY=your_key_here
+# Optional: add AI provider keys for local testing.
+# OPENAI_API_KEY=sk-your-key-here
+# ANTHROPIC_API_KEY=your-key-here
+# GOOGLE_GENERATIVE_AI_API_KEY=your-key-here
+# MISTRAL_API_KEY=your-key-here
+# XAI_API_KEY=your-key-here
+# OPENROUTER_API_KEY=sk-your-key-here
+
+# -------------------------------------------------------------
+# Supabase + Google OAuth configuration (advanced)
+# -------------------------------------------------------------
+# When you're ready to use Supabase authentication, flip the flag below to false
+# and provide the Supabase + Google OAuth credentials. Supabase project settings
+# can be found in the dashboard under Project Settings > API / Authentication.
+# NEXT_PUBLIC_DEV_AUTH=false
+# NEXT_PUBLIC_SUPABASE_URL=https://your-project.supabase.co
+# NEXT_PUBLIC_SUPABASE_ANON_KEY=your-anon-key
+# SUPABASE_SERVICE_ROLE=your-service-role-key
+#
+# # Google OAuth (match the values configured in the Google Cloud Console).
+# GOOGLE_CLIENT_ID=your-google-oauth-client-id
+# GOOGLE_CLIENT_SECRET=your-google-oauth-client-secret
+#
+# # App URLs used for redirects (update the port if you run on a different one).
+# NEXT_PUBLIC_APP_URL=http://localhost:3000
+# NEXT_PUBLIC_SITE_URL=http://localhost:3000
+# NEXTAUTH_URL=http://localhost:3000

--- a/.gitignore
+++ b/.gitignore
@@ -78,6 +78,7 @@ TEST_RESULTS.md
 TROUBLESHOOTING_AUTH.md
 DOCKER_SETUP_GUIDE.md
 QUICK_START.md
+!docs/QUICK_START.md
 
 # IDE and editor files
 .idea/

--- a/README.md
+++ b/README.md
@@ -24,16 +24,18 @@ Built on Next.js 15 with TypeScript. Supabase backend for authentication and dat
 
 ## Getting Started
 
-Clone and run locally with your preferred AI models:
+Clone and run locally with your preferred AI models. See
+[docs/QUICK_START.md](./docs/QUICK_START.md) for the complete onboarding guide
+and troubleshooting tips.
 
 ```bash
 git clone https://github.com/n3wth/bob.git
 cd bob
-npm install
-cp .env.example .env.local
+npm ci
+cp .env.local.example .env.local
 ```
 
-Add your API keys to `.env.local`:
+Add your secrets to `.env.local` (minimum required for local development):
 ```bash
 # Choose one or more AI providers
 OPENAI_API_KEY=sk-...
@@ -45,12 +47,18 @@ CSRF_SECRET=$(openssl rand -hex 16)
 ENCRYPTION_KEY=$(openssl rand -base64 32)
 ```
 
-Start the development server:
+Start the development server on a fixed port to avoid conflicts with other
+Next.js projects you might have running:
 ```bash
-npm run dev
+npm run dev -- --port=3000
 ```
 
-Open [http://localhost:3000](http://localhost:3000) and start chatting.
+If `3000` is already in use, pick another port (for example `3001`) and update
+the URLs in `.env.local` accordingly. Playwright end-to-end tests boot on port
+`3100`, so they will not interfere with your manual dev server.
+
+Open [http://localhost:3000](http://localhost:3000) (or whichever port you
+selected) and start chatting.
 
 ### Local AI with Ollama
 
@@ -70,12 +78,15 @@ npm run dev
 For advanced features including authentication, file uploads, and persistent chat history:
 
 ```bash
-cp .env.example .env.local
+cp .env.local.example .env.local
 # Configure Supabase variables in .env.local
-docker-compose -f docker-compose.dev.yml up
+docker-compose -f docker-compose.dev.yml up --build
 ```
 
-Includes PostgreSQL database, file storage, and hot reload.
+Docker maps the application to [http://localhost:3001](http://localhost:3001)
+by default to avoid clashes with a locally running Next.js instance. The stack
+includes hot reload; configure Supabase if you need authentication or
+persistent storage.
 
 ## Architecture
 

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -5,7 +5,8 @@ services:
       context: .
       dockerfile: Dockerfile.dev
     ports:
-      - "3000:3000"
+      # Expose the app on localhost:3001 to avoid clashing with other Next.js apps
+      - "3001:3000"
     env_file:
       - .env.local
     environment:

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -294,6 +294,7 @@ docker run -p 3000:3000 bob
 ## 📖 Additional Resources
 
 ### Internal Documentation
+- [Quick Start Guide](./QUICK_START.md)
 - [API Documentation](./API.md)
 - [Component Guide](./COMPONENTS.md)
 - [State Management](./STATE.md)

--- a/docs/QUICK_START.md
+++ b/docs/QUICK_START.md
@@ -1,0 +1,107 @@
+# Bob Quick Start Guide
+
+This guide walks through the minimum steps required to get Bob running locally
+and explains the different environment configurations used during
+development, testing, and authentication flows.
+
+---
+
+## 1. Install dependencies
+
+```bash
+npm ci
+```
+
+> ℹ️ `npm ci` is faster and produces a clean install that matches the lockfile.
+
+## 2. Configure environment variables
+
+Copy the sample file and update any values you need:
+
+```bash
+cp .env.local.example .env.local
+```
+
+The default values enable **development auth**, so you can sign in without
+Supabase or Google OAuth. When you are ready to integrate Supabase, flip the
+`NEXT_PUBLIC_DEV_AUTH` flag to `false` and provide the Supabase + Google OAuth
+credentials described at the bottom of `.env.local.example`.
+
+### Required secrets
+
+Even for the quick-start flow you must set:
+
+- `CSRF_SECRET` – 32 hex characters (`openssl rand -hex 16`)
+- `ENCRYPTION_KEY` – 44 character base64 string (`openssl rand -base64 32`)
+
+These values keep session security intact even in local development.
+
+## 3. Run the application
+
+Start the development server on an explicit port to avoid conflicts with other
+Next.js apps you might already be running:
+
+```bash
+npm run dev -- --port=3000
+```
+
+If port `3000` is in use, pick another one (for example `3001`) and update the
+URLs in `.env.local` accordingly. The application logs the active port on
+startup.
+
+### Docker-based workflow
+
+If you prefer Docker, the dev compose file maps the application to port 3001 to
+avoid conflicts with existing local Next.js instances:
+
+```bash
+docker compose -f docker-compose.dev.yml up --build
+```
+
+Open [http://localhost:3001](http://localhost:3001) when using Docker.
+
+## 4. Running tests
+
+Bob provides ready-to-use defaults for both unit and end-to-end tests:
+
+| Command | Purpose |
+| --- | --- |
+| `npm run test:run` | Vitest unit/integration suite with mocked Supabase env |
+| `npm run test:e2e:chromium` | Playwright e2e tests against a dev server on port 3100 |
+| `npm run lint` | ESLint static analysis |
+| `npm run type-check` | TypeScript project validation |
+
+The Playwright configuration now bootstraps its own development server on port
+`3100` and injects safe placeholder environment variables. This keeps the test
+suite isolated from whichever port you use for manual development.
+
+## 5. Google OAuth + Supabase (optional)
+
+When you switch to Supabase-backed authentication:
+
+1. Set `NEXT_PUBLIC_DEV_AUTH=false` in `.env.local`.
+2. Fill in your Supabase project URL, anon key, and service role key.
+3. Configure Google OAuth credentials (Client ID + Secret) in the Google Cloud Console.
+4. Add the following redirect URLs in Google Cloud:
+   - `http://localhost:3000/auth/callback` (or the port you use locally)
+   - `https://your-production-domain/auth/callback`
+5. Update `NEXT_PUBLIC_APP_URL`, `NEXT_PUBLIC_SITE_URL`, and `NEXTAUTH_URL`
+   to match the port/domain you plan to run on.
+
+If you encounter a Supabase UUID error, double-check that your Supabase
+migrations are up to date and that the anon/service keys belong to the same
+project.
+
+## 6. Troubleshooting checklist
+
+- **Port already in use** – Restart the dev server with `npm run dev -- --port=<new-port>`.
+- **OAuth redirect issues** – Verify callback URLs match your Google Cloud OAuth settings.
+- **Tests failing due to env vars** – Ensure `.env.local` exists or rely on the
+  defaults baked into `tests/setup.ts` and `playwright.config.ts`.
+- **Database errors** – Confirm Supabase migrations are applied and the service
+  role key is correct.
+
+---
+
+With these steps in place you should be able to bootstrap the dashboard, run
+tests reliably, and iterate on new features without wrestling the tooling.

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,5 +1,8 @@
 import { defineConfig, devices } from '@playwright/test'
 
+const e2ePort = process.env.E2E_PORT ?? '3100'
+const e2eBaseUrl = `http://127.0.0.1:${e2ePort}`
+
 export default defineConfig({
   testDir: './tests',
   fullyParallel: true,
@@ -15,7 +18,7 @@ export default defineConfig({
   ],
 
   use: {
-    baseURL: 'http://localhost:3000',
+    baseURL: e2eBaseUrl,
     trace: 'on-first-retry',
     screenshot: 'only-on-failure',
     video: 'retain-on-failure',
@@ -47,14 +50,21 @@ export default defineConfig({
   ],
 
   webServer: {
-    command: 'npm run dev',
-    url: 'http://localhost:3000',
+    command: `npm run dev -- --port=${e2ePort}`,
+    url: e2eBaseUrl,
     reuseExistingServer: !process.env.CI,
     timeout: 180 * 1000, // 3 minutes for unstable server startup
     stderr: 'pipe',
     stdout: 'pipe',
     env: {
       NODE_ENV: 'test', // Use test environment
+      PORT: e2ePort,
+      NEXT_PUBLIC_SUPABASE_URL: process.env.NEXT_PUBLIC_SUPABASE_URL ?? 'https://example.supabase.co',
+      NEXT_PUBLIC_SUPABASE_ANON_KEY: process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY ?? 'test-anon-key',
+      SUPABASE_SERVICE_ROLE: process.env.SUPABASE_SERVICE_ROLE ?? 'test-service-role',
+      CSRF_SECRET: process.env.CSRF_SECRET ?? '0123456789abcdef0123456789abcdef',
+      ENCRYPTION_KEY:
+        process.env.ENCRYPTION_KEY ?? 'c2ltcGxlLXRlc3QtZW5jcnlwdGlvbi1rZXkzMg==',
     },
   },
 })

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -71,4 +71,16 @@ Object.defineProperty(window, 'matchMedia', {
 // Mock environment variables
 beforeAll(() => {
   process.env.NODE_ENV = 'test'
+
+  // Provide safe defaults for required environment variables so Supabase-dependent
+  // modules don't throw during local tests. These values are intentionally non-secret
+  // placeholders that keep the test environment self-contained.
+  process.env.NEXT_PUBLIC_SUPABASE_URL ||= 'https://example.supabase.co'
+  process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY ||= 'test-anon-key'
+  process.env.SUPABASE_SERVICE_ROLE ||= 'test-service-role'
+
+  // Secrets required by the application during runtime. These values do not grant
+  // access to any real service – they simply satisfy runtime validations.
+  process.env.CSRF_SECRET ||= '0123456789abcdef0123456789abcdef'
+  process.env.ENCRYPTION_KEY ||= 'c2ltcGxlLXRlc3QtZW5jcnlwdGlvbi1rZXkzMg=='
 })


### PR DESCRIPTION
## Summary
- add a dedicated quick start guide and refresh README/.env samples so developers have clear setup steps
- expose the dev container on a conflict-free port and unignore the quick start doc so it ships with the repo
- ensure Playwright and Vitest provide safe default environment variables and run on an isolated test port

## Testing
- npm run lint *(fails: existing lint issues in untouched files)*
- npm run type-check
- npm run test:run

------
https://chatgpt.com/codex/tasks/task_e_68d363379dbc832a865474f6c874e216