### PR TITLE
Move multi-chat selection sync into effect to avoid hydration loop

### DIFF
--- a/app/components/multi-chat/multi-chat.tsx
+++ b/app/components/multi-chat/multi-chat.tsx
@@ -82,9 +82,11 @@ export function MultiChat() {
     return availableModels.filter((model) => combined.includes(model.id))
   }, [availableModels, selectedModelIds, modelsFromPersisted])
 
-  if (selectedModelIds.length === 0 && modelsFromLastGroup.length > 0) {
-    setSelectedModelIds(modelsFromLastGroup)
-  }
+  useEffect(() => {
+    if (selectedModelIds.length === 0 && modelsFromLastGroup.length > 0) {
+      setSelectedModelIds(modelsFromLastGroup)
+    }
+  }, [modelsFromLastGroup, selectedModelIds.length])
 
   const modelChats = useMultiChat(allModelsToMaintain)
   const systemPrompt = useMemo(


### PR DESCRIPTION
## Summary
- move the persisted multi-model selection restoration into a client effect so it no longer runs during render
- prevent repeated render loops that slowed hydration and triggered the timeout described in GH-8

## Testing
- npm run lint *(fails: repository currently contains numerous pre-existing lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68d363334f18832ab69db37d16a2eb61