### PR TITLE
Fix CSP for analytics and remove remote font import

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -1,4 +1,3 @@
-@import url('https://fonts.googleapis.com/css2?family=Inter:wght@100..900&display=swap');
 @import "tailwindcss";
 
 @plugin "@tailwindcss/typography";


### PR DESCRIPTION
## Summary
- stop requesting Inter from Google Fonts and rely on the bundled Geist font to avoid CSP violations
- refactor middleware CSP generation and allow Vercel Analytics along with necessary font sources in both dev and prod
- expand CSP connect directives so analytics beacons are not blocked by the browser

## Testing
- npm run lint *(fails: existing lint errors unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68d3632b83e0832aab72ffa4c95a4658