### PR TITLE
Improve chat send button feedback

### DIFF
--- a/app/components/chat-input/chat-input.tsx
+++ b/app/components/chat-input/chat-input.tsx
@@ -9,7 +9,8 @@ import {
 } from "@/components/prompt-kit/prompt-input"
 import { Button } from "@/components/ui/button"
 import { getModelInfo } from "@/lib/models"
-import { ArrowUpIcon, StopIcon } from "@phosphor-icons/react"
+import { cn } from "@/lib/utils"
+import { ArrowUpIcon, Spinner, StopIcon } from "@phosphor-icons/react"
 import { useCallback, useEffect, useMemo, useRef } from "react"
 import { PromptSystem } from "../suggestions/prompt-system"
 import { ButtonFileUpload } from "./button-file-upload"
@@ -67,9 +68,28 @@ export function ChatInput({
   const hasInput = value.length > 0 && !isOnlyWhitespace(value)
   const isStreaming = status === "streaming"
   const isAwaitingResponse = status === "submitted"
+  const isProcessingMessage = !isStreaming && (isSubmitting || isAwaitingResponse)
   const isSendDisabled = !isStreaming && (!hasInput || isSubmitting || isAwaitingResponse)
   const isErrored = status === "error"
   const errorMessageId = isErrored ? "chat-input-error" : undefined
+
+  const sendButtonState = isStreaming
+    ? "streaming"
+    : isProcessingMessage
+      ? "loading"
+      : "idle"
+  const sendButtonTooltip =
+    sendButtonState === "streaming"
+      ? "Stop"
+      : sendButtonState === "loading"
+        ? "Sending"
+        : "Send"
+  const sendButtonAriaLabel =
+    sendButtonState === "streaming"
+      ? "Stop response"
+      : sendButtonState === "loading"
+        ? "Sending message"
+        : "Send message"
 
   const handleSend = useCallback(() => {
     if (isSubmitting) {
@@ -219,24 +239,35 @@ export function ChatInput({
                 />
               ) : null}
             </div>
-            <PromptInputAction
-              tooltip={status === "streaming" ? "Stop" : "Send"}
-            >
+            <PromptInputAction tooltip={sendButtonTooltip}>
               <Button
                 id="chat-send-button"
                 data-testid="chat-send-button"
-                size="sm"
-                className="size-9 rounded-full transition-all duration-300 ease-out"
+                size="icon"
+                className={cn(
+                  "group relative size-9 rounded-full bg-white text-black shadow-[0_10px_30px_rgba(15,15,15,0.2)]",
+                  "transition-all duration-200 ease-out",
+                  "hover:-translate-y-0.5 hover:bg-white/90 hover:shadow-[0_18px_40px_rgba(15,15,15,0.28)]",
+                  "active:scale-95",
+                  "disabled:translate-y-0 disabled:bg-white/15 disabled:text-white/50 disabled:shadow-none disabled:!opacity-80 disabled:!cursor-not-allowed",
+                  "data-[state=streaming]:bg-rose-500 data-[state=streaming]:text-white",
+                  "data-[state=streaming]:hover:bg-rose-500/90 data-[state=streaming]:shadow-[0_16px_36px_rgba(244,63,94,0.45)] data-[state=streaming]:hover:shadow-[0_20px_44px_rgba(244,63,94,0.5)]",
+                  "data-[state=loading]:bg-white/70 data-[state=loading]:text-black/70 data-[state=loading]:shadow-[0_10px_30px_rgba(255,255,255,0.2)]",
+                  "data-[state=loading]:!cursor-wait data-[state=loading]:!opacity-100"
+                )}
                 disabled={isSendDisabled}
                 type="button"
                 onClick={handleSend}
-                aria-label={status === "streaming" ? "Stop" : "Send message"}
+                aria-label={sendButtonAriaLabel}
                 aria-busy={isSubmitting || isStreaming || isAwaitingResponse}
+                data-state={sendButtonState}
               >
-                {status === "streaming" ? (
-                  <StopIcon className="size-4" />
+                {sendButtonState === "streaming" ? (
+                  <StopIcon className="size-4 transition-transform duration-200 group-hover:scale-105" />
+                ) : sendButtonState === "loading" ? (
+                  <Spinner className="size-4 animate-spin" />
                 ) : (
-                  <ArrowUpIcon className="size-4" />
+                  <ArrowUpIcon className="size-4 transition-transform duration-200 group-hover:-translate-y-0.5 group-active:translate-y-0 group-active:scale-90" />
                 )}
               </Button>
             </PromptInputAction>


### PR DESCRIPTION
## Summary
- enhance the chat send button with new hover, active, loading, and streaming visual states
- show a spinner while a message is being submitted and improve accessibility labels

## Testing
- npm run lint *(fails: existing lint errors in unrelated files)*
- npm run type-check
- npm run test:coverage

------
https://chatgpt.com/codex/tasks/task_e_68d39c7dccf0832abcd6cf06f1911322