### PR TITLE
feat: add loading skeletons

### DIFF
--- a/app/components/chat/chat-skeleton.tsx
+++ b/app/components/chat/chat-skeleton.tsx
@@ -1,0 +1,132 @@
+"use client"
+
+import { ChatContainerContent, ChatContainerRoot } from "@/components/prompt-kit/chat-container"
+import { Skeleton } from "@/components/ui/skeleton"
+import { cn } from "@/lib/utils"
+
+function MessageSkeleton({ variant = "assistant" }: { variant?: "user" | "assistant" }) {
+  const justify = variant === "user" ? "justify-end" : "justify-start"
+  const bubbleAlignment = variant === "user" ? "items-end" : "items-start"
+  const bubbleBackground =
+    variant === "user" ? "bg-primary/10 border-primary/20" : "bg-muted/40 border-border/40"
+
+  return (
+    <div className={cn("flex w-full px-6", justify)}>
+      <div className="w-full max-w-3xl">
+        <div
+          className={cn(
+            "flex w-full flex-col gap-3 rounded-3xl border p-4 shadow-sm backdrop-blur",
+            bubbleAlignment,
+            bubbleBackground
+          )}
+        >
+          <Skeleton className="h-3.5 w-32 rounded-full" />
+          <Skeleton className="h-4 w-full" />
+          <Skeleton className="h-4 w-2/3" />
+        </div>
+      </div>
+    </div>
+  )
+}
+
+function ResponseCardSkeleton() {
+  return (
+    <div className="bg-background/80 w-full max-w-[420px] flex-shrink-0 rounded-2xl border border-border/50 p-4 shadow-sm backdrop-blur">
+      <Skeleton className="mb-4 h-3 w-20 rounded-full" />
+      <div className="space-y-3">
+        <Skeleton className="h-4 w-full" />
+        <Skeleton className="h-4 w-5/6" />
+        <Skeleton className="h-4 w-3/4" />
+      </div>
+    </div>
+  )
+}
+
+export function ConversationSkeleton({ responseCount = 0 }: { responseCount?: number }) {
+  const showResponses = responseCount > 0
+  const responsesToRender = showResponses ? Array.from({ length: responseCount }) : []
+
+  return (
+    <div className="relative flex h-full w-full flex-col items-center overflow-hidden">
+      <div className="pointer-events-none absolute top-0 right-0 left-0 z-20 mx-auto flex w-full flex-col justify-center">
+        <div className="flex h-[56px] w-full bg-background" />
+        <div className="flex h-4 w-full bg-gradient-to-b from-background to-transparent" />
+      </div>
+      <ChatContainerRoot className="relative h-full w-full overflow-y-auto overflow-x-hidden">
+        <ChatContainerContent
+          className="flex w-full flex-col items-center gap-6 pt-32 pb-4"
+          style={{
+            scrollbarGutter: "stable both-edges",
+            scrollbarWidth: "none",
+          }}
+        >
+          <MessageSkeleton variant="user" />
+          {showResponses ? (
+            <div className="w-full px-6">
+              <div
+                className={cn(
+                  "mx-auto flex w-full gap-4",
+                  responseCount > 1 ? "max-w-[1800px]" : "max-w-3xl",
+                  "overflow-hidden"
+                )}
+              >
+                {responsesToRender.map((_, index) => (
+                  <ResponseCardSkeleton key={`response-skeleton-${index}`} />
+                ))}
+                <div className="w-px flex-shrink-0" />
+              </div>
+            </div>
+          ) : (
+            <>
+              <MessageSkeleton variant="assistant" />
+              <MessageSkeleton variant="assistant" />
+            </>
+          )}
+        </ChatContainerContent>
+      </ChatContainerRoot>
+    </div>
+  )
+}
+
+export function ChatInputSkeleton({
+  className,
+  withModelSelector = false,
+}: {
+  className?: string
+  withModelSelector?: boolean
+}) {
+  return (
+    <div
+      className={cn(
+        "border-input bg-background/80 relative z-10 rounded-3xl border p-4 shadow-xs backdrop-blur",
+        className
+      )}
+    >
+      <Skeleton className="h-16 w-full rounded-2xl" />
+      <div className="mt-4 flex items-center justify-between gap-3">
+        <div className="flex items-center gap-2">
+          {withModelSelector ? (
+            <>
+              <Skeleton className="h-5 w-24 rounded-md" />
+              <Skeleton className="h-5 w-16 rounded-md" />
+            </>
+          ) : (
+            <Skeleton className="h-5 w-28 rounded-md" />
+          )}
+        </div>
+        <Skeleton className="h-9 w-9 rounded-full" />
+      </div>
+    </div>
+  )
+}
+
+export function ChatPageSkeleton({ variant = "single" }: { variant?: "single" | "multi" }) {
+  return (
+    <div className="@container/main relative flex h-full flex-col items-center justify-end md:justify-center">
+      <ConversationSkeleton responseCount={variant === "multi" ? 2 : 0} />
+      <div className="relative inset-x-0 bottom-0 z-50 mx-auto w-full max-w-3xl">
+        <ChatInputSkeleton withModelSelector={variant === "multi"} />
+      </div>
+    </div>
+  )
+}

--- a/app/components/layout/sidebar/app-sidebar.tsx
+++ b/app/components/layout/sidebar/app-sidebar.tsx
@@ -7,9 +7,11 @@ import {
   SidebarContent,
   SidebarFooter,
   SidebarHeader,
+  SidebarMenuSkeleton,
   useSidebar,
 } from "@/components/ui/sidebar"
 import { Logo } from "@/components/ui/logo"
+import { Skeleton } from "@/components/ui/skeleton"
 import { useChats } from "@/lib/chat-store/chats/provider"
 import {
   ChatTeardropText,
@@ -96,7 +98,28 @@ export function AppSidebar() {
           </div>
           <SidebarProject />
           {isLoading ? (
-            <div className="h-full" />
+            <div className="space-y-6 py-2">
+              <div className="space-y-2">
+                <Skeleton className="mx-2 h-3 w-20 rounded-full" />
+                {Array.from({ length: 3 }).map((_, index) => (
+                  <SidebarMenuSkeleton
+                    key={`sidebar-loading-${index}`}
+                    className="px-2"
+                    showIcon
+                  />
+                ))}
+              </div>
+              <div className="space-y-2">
+                <Skeleton className="mx-2 h-3 w-24 rounded-full" />
+                {Array.from({ length: 4 }).map((_, index) => (
+                  <SidebarMenuSkeleton
+                    key={`sidebar-loading-secondary-${index}`}
+                    className="px-2"
+                    showIcon
+                  />
+                ))}
+              </div>
+            </div>
           ) : hasChats ? (
             <div className="space-y-5">
               {pinnedChats.length > 0 && (

--- a/app/components/layout/sidebar/sidebar-project.tsx
+++ b/app/components/layout/sidebar/sidebar-project.tsx
@@ -1,6 +1,7 @@
 "use client"
 
 import { FolderPlusIcon } from "@phosphor-icons/react"
+import { Skeleton } from "@/components/ui/skeleton"
 import { useQuery } from "@tanstack/react-query"
 import { useState } from "react"
 import { DialogCreateProject } from "./dialog-create-project"
@@ -40,7 +41,22 @@ export function SidebarProject() {
         </div>
       </button>
 
-      {isLoading ? null : (
+      {isLoading ? (
+        <div className="space-y-1">
+          {Array.from({ length: 2 }).map((_, index) => (
+            <div
+              key={`project-skeleton-${index}`}
+              className="flex items-center justify-between rounded-md px-2 py-2"
+            >
+              <div className="flex items-center gap-2">
+                <Skeleton className="h-4 w-4 rounded-sm" />
+                <Skeleton className="h-4 w-32 rounded-md" />
+              </div>
+              <Skeleton className="h-4 w-6 rounded-md" />
+            </div>
+          ))}
+        </div>
+      ) : (
         <div className="space-y-1">
           {projects.map((project) => (
             <SidebarProjectItem key={project.id} project={project} />

--- a/app/components/multi-chat/multi-chat.tsx
+++ b/app/components/multi-chat/multi-chat.tsx
@@ -1,6 +1,7 @@
 "use client"
 
 import { MultiModelConversation } from "@/app/components/multi-chat/multi-conversation"
+import { ChatInputSkeleton, ConversationSkeleton } from "@/app/components/chat/chat-skeleton"
 import { toast } from "@/components/ui/toast"
 import { getOrCreateGuestUserId } from "@/lib/api"
 import { useChats } from "@/lib/chat-store/chats/provider"
@@ -333,6 +334,17 @@ export function MultiChat() {
 
   const conversationProps = useMemo(() => ({ messageGroups }), [messageGroups])
 
+  const skeletonResponseCount = useMemo(
+    () =>
+      Math.max(
+        selectedModelIds.length ||
+          modelsFromLastGroup.length ||
+          modelsFromPersisted.length,
+        2
+      ),
+    [modelsFromLastGroup, modelsFromPersisted, selectedModelIds]
+  )
+
   const inputProps = useMemo(
     () => ({
       value: prompt,
@@ -363,6 +375,7 @@ export function MultiChat() {
     ]
   )
 
+  const showInitialLoading = messagesLoading && messageGroups.length === 0
   const showOnboarding = messageGroups.length === 0 && !messagesLoading
 
   // Refresh greeting periodically to keep it time-aware
@@ -382,7 +395,20 @@ export function MultiChat() {
       )}
     >
       <AnimatePresence initial={false} mode="popLayout">
-        {showOnboarding ? (
+        {showInitialLoading ? (
+          <motion.div
+            key="multi-loading"
+            className="w-full flex-1 overflow-hidden"
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+            layout="position"
+            layoutId="conversation-loading"
+            transition={{ layout: { duration: 0 } }}
+          >
+            <ConversationSkeleton responseCount={skeletonResponseCount} />
+          </motion.div>
+        ) : showOnboarding ? (
           <motion.div
             key="onboarding"
             className="absolute bottom-[60%] mx-auto max-w-[50rem] md:relative md:bottom-auto"
@@ -418,7 +444,14 @@ export function MultiChat() {
           showOnboarding ? "relative" : "absolute right-0 bottom-0 left-0"
         )}
       >
-        <MultiChatInput {...inputProps} />
+        {showInitialLoading ? (
+          <ChatInputSkeleton
+            className="bg-popover/80"
+            withModelSelector
+          />
+        ) : (
+          <MultiChatInput {...inputProps} />
+        )}
       </div>
     </div>
   )

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -2,6 +2,7 @@ import { ChatContainer } from "@/app/components/chat/chat-container"
 import { LayoutApp } from "@/app/components/layout/layout-app"
 import { MessagesProvider } from "@/lib/chat-store/messages/provider"
 import { Suspense } from "react"
+import { ChatPageSkeleton } from "@/app/components/chat/chat-skeleton"
 
 export const dynamic = "force-dynamic"
 
@@ -9,7 +10,7 @@ export default function Home() {
   return (
     <MessagesProvider>
       <LayoutApp>
-        <Suspense>
+        <Suspense fallback={<ChatPageSkeleton />}>
           <ChatContainer />
         </Suspense>
       </LayoutApp>


### PR DESCRIPTION
## Summary
- add reusable chat conversation and input skeletons with a Suspense fallback on the home page
- wire the single and multi-model chat flows to show loading skeletons while fetching chats or messages
- show skeleton placeholders for sidebar chat history and projects while their data loads

## Testing
- npm run lint *(fails: existing repository lint errors outside the touched files)*
- npm run type-check


------
https://chatgpt.com/codex/tasks/task_e_68d39ac547a4832a89d50d4722414f13