### PR TITLE
feat: add markdown syntax highlighting

### DIFF
--- a/app/components/chat/message-assistant.tsx
+++ b/app/components/chat/message-assistant.tsx
@@ -120,7 +120,7 @@ export function MessageAssistant({
           <MessageContent
             className={cn(
               "prose dark:prose-invert relative min-w-full bg-transparent p-0",
-              "prose-h1:scroll-m-20 prose-h1:text-2xl prose-h1:font-semibold prose-h2:mt-8 prose-h2:scroll-m-20 prose-h2:text-xl prose-h2:mb-3 prose-h2:font-medium prose-h3:scroll-m-20 prose-h3:text-base prose-h3:font-medium prose-h4:scroll-m-20 prose-h5:scroll-m-20 prose-h6:scroll-m-20 prose-strong:font-medium prose-table:block prose-table:overflow-y-auto"
+              "prose-h1:scroll-m-20 prose-h1:text-2xl prose-h1:font-semibold prose-h2:mt-8 prose-h2:scroll-m-20 prose-h2:text-xl prose-h2:mb-3 prose-h2:font-medium prose-h3:scroll-m-20 prose-h3:text-base prose-h3:font-medium prose-h4:scroll-m-20 prose-h5:scroll-m-20 prose-h6:scroll-m-20 prose-strong:font-medium prose-table:block prose-table:overflow-x-auto"
             )}
             markdown={true}
           >

--- a/app/components/chat/message-user.tsx
+++ b/app/components/chat/message-user.tsx
@@ -155,23 +155,9 @@ export function MessageUser({
         </div>
       ) : (
         <MessageContent
-          className="bg-accent prose dark:prose-invert relative max-w-[70%] rounded-3xl px-5 py-2.5"
+          className="bg-accent prose dark:prose-invert relative max-w-[70%] rounded-3xl px-5 py-2.5 prose-table:block prose-table:overflow-x-auto"
           markdown={true}
           ref={contentRef}
-          components={{
-            code: ({ children }) => <>{children}</>,
-            pre: ({ children }) => <>{children}</>,
-            h1: ({ children }) => <p>{children}</p>,
-            h2: ({ children }) => <p>{children}</p>,
-            h3: ({ children }) => <p>{children}</p>,
-            h4: ({ children }) => <p>{children}</p>,
-            h5: ({ children }) => <p>{children}</p>,
-            h6: ({ children }) => <p>{children}</p>,
-            p: ({ children }) => <p>{children}</p>,
-            li: ({ children }) => <p>- {children}</p>,
-            ul: ({ children }) => <>{children}</>,
-            ol: ({ children }) => <>{children}</>,
-          }}
         >
           {children}
         </MessageContent>

--- a/components/prompt-kit/code-block.tsx
+++ b/components/prompt-kit/code-block.tsx
@@ -1,10 +1,16 @@
 "use client"
 
 import { cn } from "@/lib/utils"
-import React from "react"
+import { useTheme } from "next-themes"
+import { useEffect, useMemo, useState, type ReactNode } from "react"
+import type {
+  BundledLanguage,
+  BundledTheme,
+  Highlighter,
+} from "shiki/bundle/web"
 
 export type CodeBlockProps = {
-  children?: React.ReactNode
+  children?: ReactNode
   className?: string
 } & React.HTMLProps<HTMLDivElement>
 
@@ -30,24 +36,164 @@ export type CodeBlockCodeProps = {
   className?: string
 } & React.HTMLProps<HTMLDivElement>
 
+type ShikiBundle = {
+  highlighter: Highlighter
+  resolveLanguage: (language?: string) => BundledLanguage | null
+}
+
+const PLAIN_TEXT_LANGUAGES = new Set([
+  "",
+  "text",
+  "plaintext",
+  "plain",
+  "nohighlight",
+  "no-highlight",
+])
+
+let shikiBundlePromise: Promise<ShikiBundle> | null = null
+const loadedLanguages = new Set<BundledLanguage>()
+
+async function loadShikiBundle(): Promise<ShikiBundle> {
+  if (!shikiBundlePromise) {
+    shikiBundlePromise = import("shiki/bundle/web").then(async (mod) => {
+      const { getSingletonHighlighter, bundledLanguagesInfo } = mod
+
+      const aliasMap = new Map<string, BundledLanguage>()
+      for (const info of bundledLanguagesInfo) {
+        const id = info.id as BundledLanguage
+        aliasMap.set(info.id.toLowerCase(), id)
+
+        if (info.aliases) {
+          for (const alias of info.aliases) {
+            aliasMap.set(alias.toLowerCase(), id)
+          }
+        }
+      }
+
+      const highlighter = await getSingletonHighlighter({
+        themes: ["github-dark", "github-light"],
+      })
+
+      return {
+        highlighter,
+        resolveLanguage(language?: string) {
+          if (!language) return null
+          const normalized = language.toLowerCase()
+          if (PLAIN_TEXT_LANGUAGES.has(normalized)) return null
+          return aliasMap.get(normalized) ?? null
+        },
+      }
+    })
+  }
+
+  return shikiBundlePromise
+}
+
+async function ensureLanguageLoaded(
+  highlighter: Highlighter,
+  language: BundledLanguage
+) {
+  if (loadedLanguages.has(language)) return
+
+  const loaded = highlighter.getLoadedLanguages()
+  if (!loaded.includes(language)) {
+    await highlighter.loadLanguage(language)
+  }
+
+  loadedLanguages.add(language)
+}
+
+function formatHighlightedHtml(html: string, language: BundledLanguage) {
+  return html.replace(
+    /<pre class="shiki([^"]*)"/,
+    `<pre data-language="${language}" class="shiki overflow-x-auto rounded-none px-4 py-4 text-[13px] leading-6$1"`
+  )
+}
+
 function CodeBlockCode({
   code,
-  language = "tsx",
+  language,
   className,
   ...props
 }: CodeBlockCodeProps) {
-  const classNames = cn(
-    "w-full overflow-x-auto text-[13px]",
-    className
-  )
+  const { resolvedTheme } = useTheme()
+  const theme: BundledTheme =
+    resolvedTheme === "light" ? "github-light" : "github-dark"
 
-  // Simple code display without syntax highlighting
-  // To re-enable syntax highlighting: npm install shiki and restore the original code
+  const normalizedCode = useMemo(() => {
+    if (!code) return ""
+    return code.replace(/\r?\n$/, "")
+  }, [code])
+
+  const normalizedLanguage = useMemo(() => language?.toLowerCase(), [language])
+  const [highlightedHtml, setHighlightedHtml] = useState<string | null>(null)
+
+  useEffect(() => {
+    let isMounted = true
+
+    async function highlight() {
+      if (!normalizedCode) {
+        if (isMounted) setHighlightedHtml(null)
+        return
+      }
+
+      try {
+        if (!normalizedLanguage || PLAIN_TEXT_LANGUAGES.has(normalizedLanguage)) {
+          if (isMounted) setHighlightedHtml(null)
+          return
+        }
+
+        const { highlighter, resolveLanguage } = await loadShikiBundle()
+        const resolvedLanguage = resolveLanguage(normalizedLanguage)
+
+        if (!resolvedLanguage) {
+          if (isMounted) setHighlightedHtml(null)
+          return
+        }
+
+        await ensureLanguageLoaded(highlighter, resolvedLanguage)
+
+        const html = await highlighter.codeToHtml(normalizedCode, {
+          lang: resolvedLanguage,
+          theme,
+        })
+
+        if (!isMounted) return
+
+        setHighlightedHtml(formatHighlightedHtml(html, resolvedLanguage))
+      } catch (error) {
+        console.error("Failed to highlight code block", error)
+        if (isMounted) setHighlightedHtml(null)
+      }
+    }
+
+    highlight()
+
+    return () => {
+      isMounted = false
+    }
+  }, [normalizedCode, normalizedLanguage, theme])
+
+  const classNames = cn("relative w-full font-mono text-[13px]", className)
+  const fallbackCode = normalizedCode || ""
+
   return (
     <div className={classNames} {...props}>
-      <pre className="px-4 py-4 !bg-background">
-        <code className="language-{language}">{code || ""}</code>
-      </pre>
+      {highlightedHtml ? (
+        <div
+          className="w-full [&_pre]:m-0"
+          dangerouslySetInnerHTML={{ __html: highlightedHtml }}
+        />
+      ) : (
+        <pre
+          className="overflow-x-auto rounded-none px-4 py-4 !bg-background"
+          data-language={normalizedLanguage ?? "text"}
+        >
+          <code className={normalizedLanguage ? `language-${normalizedLanguage}` : undefined}>
+            {fallbackCode}
+          </code>
+        </pre>
+      )}
     </div>
   )
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -58,6 +58,7 @@
         "react-nice-avatar": "^1.5.0",
         "remark-breaks": "^4.0.0",
         "remark-gfm": "^4.0.1",
+        "shiki": "^3.13.0",
         "sonner": "^2.0.1",
         "tailwind-merge": "^3.0.2",
         "tailwindcss-animate": "^1.0.7",
@@ -3700,6 +3701,73 @@
       "resolved": "https://registry.npmjs.org/@rushstack/eslint-patch/-/eslint-patch-1.12.0.tgz",
       "integrity": "sha512-5EwMtOqvJMMa3HbmxLlF74e+3/HhwBTMcvt3nqVJgGCozO6hzIPOBlwm8mGVNR9SN2IJpxSnlxczyDjcn7qIyw==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@shikijs/core": {
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/core/-/core-3.13.0.tgz",
+      "integrity": "sha512-3P8rGsg2Eh2qIHekwuQjzWhKI4jV97PhvYjYUzGqjvJfqdQPz+nMlfWahU24GZAyW1FxFI1sYjyhfh5CoLmIUA==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "3.13.0",
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.4",
+        "hast-util-to-html": "^9.0.5"
+      }
+    },
+    "node_modules/@shikijs/engine-javascript": {
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/engine-javascript/-/engine-javascript-3.13.0.tgz",
+      "integrity": "sha512-Ty7xv32XCp8u0eQt8rItpMs6rU9Ki6LJ1dQOW3V/56PKDcpvfHPnYFbsx5FFUP2Yim34m/UkazidamMNVR4vKg==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "3.13.0",
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "oniguruma-to-es": "^4.3.3"
+      }
+    },
+    "node_modules/@shikijs/engine-oniguruma": {
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-3.13.0.tgz",
+      "integrity": "sha512-O42rBGr4UDSlhT2ZFMxqM7QzIU+IcpoTMzb3W7AlziI1ZF7R8eS2M0yt5Ry35nnnTX/LTLXFPUjRFCIW+Operg==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "3.13.0",
+        "@shikijs/vscode-textmate": "^10.0.2"
+      }
+    },
+    "node_modules/@shikijs/langs": {
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/langs/-/langs-3.13.0.tgz",
+      "integrity": "sha512-672c3WAETDYHwrRP0yLy3W1QYB89Hbpj+pO4KhxK6FzIrDI2FoEXNiNCut6BQmEApYLfuYfpgOZaqbY+E9b8wQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "3.13.0"
+      }
+    },
+    "node_modules/@shikijs/themes": {
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/themes/-/themes-3.13.0.tgz",
+      "integrity": "sha512-Vxw1Nm1/Od8jyA7QuAenaV78BG2nSr3/gCGdBkLpfLscddCkzkL36Q5b67SrLLfvAJTOUzW39x4FHVCFriPVgg==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "3.13.0"
+      }
+    },
+    "node_modules/@shikijs/types": {
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/types/-/types-3.13.0.tgz",
+      "integrity": "sha512-oM9P+NCFri/mmQ8LoFGVfVyemm5Hi27330zuOBp0annwJdKH1kOLndw3zCtAVDehPLg9fKqoEx3Ht/wNZxolfw==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.4"
+      }
+    },
+    "node_modules/@shikijs/vscode-textmate": {
+      "version": "10.0.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/vscode-textmate/-/vscode-textmate-10.0.2.tgz",
+      "integrity": "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==",
       "license": "MIT"
     },
     "node_modules/@supabase/auth-js": {
@@ -7779,6 +7847,29 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/hast-util-to-html": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/hast-util-to-html/-/hast-util-to-html-9.0.5.tgz",
+      "integrity": "sha512-OguPdidb+fbHQSU4Q4ZiLKnzWo8Wwsf5bZfbvu7//a9oTYoqD/fWpe96NuHkoS9h0ccGOTe0C4NGXdtS0iObOw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/unist": "^3.0.0",
+        "ccount": "^2.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "hast-util-whitespace": "^3.0.0",
+        "html-void-elements": "^3.0.0",
+        "mdast-util-to-hast": "^13.0.0",
+        "property-information": "^7.0.0",
+        "space-separated-tokens": "^2.0.0",
+        "stringify-entities": "^4.0.0",
+        "zwitch": "^2.0.4"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/hast-util-to-jsx-runtime": {
       "version": "2.3.6",
       "resolved": "https://registry.npmjs.org/hast-util-to-jsx-runtime/-/hast-util-to-jsx-runtime-2.3.6.tgz",
@@ -7847,6 +7938,16 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/html-void-elements": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/html-void-elements/-/html-void-elements-3.0.0.tgz",
+      "integrity": "sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/http-proxy-agent": {
@@ -10506,6 +10607,23 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/oniguruma-parser": {
+      "version": "0.12.1",
+      "resolved": "https://registry.npmjs.org/oniguruma-parser/-/oniguruma-parser-0.12.1.tgz",
+      "integrity": "sha512-8Unqkvk1RYc6yq2WBYRj4hdnsAxVze8i7iPfQr8e4uSP3tRv0rpZcbGUDvxfQQcdwHt/e9PrMvGCsa8OqG9X3w==",
+      "license": "MIT"
+    },
+    "node_modules/oniguruma-to-es": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/oniguruma-to-es/-/oniguruma-to-es-4.3.3.tgz",
+      "integrity": "sha512-rPiZhzC3wXwE59YQMRDodUwwT9FZ9nNBwQQfsd1wfdtlKEyCdRV0avrTcSZ5xlIvGRVPd/cx6ZN45ECmS39xvg==",
+      "license": "MIT",
+      "dependencies": {
+        "oniguruma-parser": "^0.12.1",
+        "regex": "^6.0.1",
+        "regex-recursion": "^6.0.2"
+      }
+    },
     "node_modules/opener": {
       "version": "1.5.2",
       "resolved": "https://registry.npmjs.org/opener/-/opener-1.5.2.tgz",
@@ -11098,6 +11216,30 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/regex": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/regex/-/regex-6.0.1.tgz",
+      "integrity": "sha512-uorlqlzAKjKQZ5P+kTJr3eeJGSVroLKoHmquUj4zHWuR+hEyNqlXsSKlYYF5F4NI6nl7tWCs0apKJ0lmfsXAPA==",
+      "license": "MIT",
+      "dependencies": {
+        "regex-utilities": "^2.3.0"
+      }
+    },
+    "node_modules/regex-recursion": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/regex-recursion/-/regex-recursion-6.0.2.tgz",
+      "integrity": "sha512-0YCaSCq2VRIebiaUviZNs0cBz1kg5kVS2UKUfNIx8YVs1cN3AV7NTctO5FOKBA+UT2BPJIWZauYHPqJODG50cg==",
+      "license": "MIT",
+      "dependencies": {
+        "regex-utilities": "^2.3.0"
+      }
+    },
+    "node_modules/regex-utilities": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/regex-utilities/-/regex-utilities-2.3.0.tgz",
+      "integrity": "sha512-8VhliFJAWRaUiVvREIiW2NXXTmHs4vMNnSzuJVhscgmGav3g9VDxLrQndI3dZZVVdp0ZO/5v0xmX516/7M9cng==",
+      "license": "MIT"
+    },
     "node_modules/regexp.prototype.flags": {
       "version": "1.5.4",
       "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.4.tgz",
@@ -11548,6 +11690,22 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/shiki": {
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/shiki/-/shiki-3.13.0.tgz",
+      "integrity": "sha512-aZW4l8Og16CokuCLf8CF8kq+KK2yOygapU5m3+hoGw0Mdosc6fPitjM+ujYarppj5ZIKGyPDPP1vqmQhr+5/0g==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/core": "3.13.0",
+        "@shikijs/engine-javascript": "3.13.0",
+        "@shikijs/engine-oniguruma": "3.13.0",
+        "@shikijs/langs": "3.13.0",
+        "@shikijs/themes": "3.13.0",
+        "@shikijs/types": "3.13.0",
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.4"
       }
     },
     "node_modules/side-channel": {

--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
     "react-nice-avatar": "^1.5.0",
     "remark-breaks": "^4.0.0",
     "remark-gfm": "^4.0.1",
+    "shiki": "^3.13.0",
     "sonner": "^2.0.1",
     "tailwind-merge": "^3.0.2",
     "tailwindcss-animate": "^1.0.7",


### PR DESCRIPTION
## Summary
- integrate Shiki-based syntax highlighting for Markdown code blocks, including dynamic theme detection and graceful fallbacks
- normalize Markdown parsing to trim code text, reuse copy controls, and keep inline code styling consistent
- render full Markdown content for user messages and tighten table overflow handling for both chat roles

## Testing
- npm run lint *(fails: repository has pre-existing lint and type errors)*
- npx eslint components/prompt-kit/markdown.tsx components/prompt-kit/code-block.tsx app/components/chat/message-user.tsx app/components/chat/message-assistant.tsx

------
https://chatgpt.com/codex/tasks/task_e_68d39ab2a8a8832a91e46f644b6b51c7