### PR TITLE
feat: add adaptive theme toggle

### DIFF
--- a/app/auth/error/page.tsx
+++ b/app/auth/error/page.tsx
@@ -17,7 +17,7 @@ function AuthErrorContent() {
   return (
     <div className="w-full max-w-md space-y-8">
       <div className="text-center">
-        <h1 className="text-3xl font-medium tracking-tight text-white sm:text-4xl">
+        <h1 className="text-3xl font-medium tracking-tight text-foreground sm:text-4xl">
           Authentication Error
         </h1>
         <div className="mt-6 rounded-md bg-red-500/10 p-4">
@@ -40,14 +40,14 @@ function AuthErrorContent() {
 
 export default function AuthErrorPage() {
   return (
-    <div className="flex h-screen flex-col bg-zinc-800 text-white">
+    <div className="bg-background text-foreground flex h-screen flex-col">
       {/* Header */}
       <header className="p-4">
         <Link
           href="/"
-          className="inline-flex items-center gap-1 rounded-md px-2 py-1 text-white hover:bg-zinc-700"
+          className="text-foreground hover:bg-muted inline-flex items-center gap-1 rounded-md px-2 py-1"
         >
-          <ArrowLeft className="size-5 text-white" />
+          <ArrowLeft className="size-5" />
           <span className="font-base ml-2 hidden text-sm sm:inline-block">
             Back to Chat
           </span>
@@ -60,10 +60,10 @@ export default function AuthErrorPage() {
         </Suspense>
       </main>
 
-      <footer className="py-6 text-center text-sm text-zinc-500">
+      <footer className="py-6 text-center text-sm text-muted-foreground">
         <p>
           Need help? {/* @todo */}
-          <Link href="/" className="text-zinc-400 hover:underline">
+          <Link href="/" className="text-foreground hover:underline">
             Contact Support
           </Link>
         </p>

--- a/app/components/chat-input/chat-input.tsx
+++ b/app/components/chat-input/chat-input.tsx
@@ -183,7 +183,7 @@ export function ChatInput({
         onClick={() => textareaRef.current?.focus()}
       >
         <PromptInput
-          className="bg-black text-white relative z-10 p-0 pt-1 shadow-xs backdrop-blur-xl border-white/20"
+          className="relative z-10 border-border/60 bg-background/95 p-0 pt-1 text-foreground shadow-xs backdrop-blur-xl"
           maxHeight={200}
           value={value}
           onValueChange={onValueChange}

--- a/app/components/chat-input/file-items.tsx
+++ b/app/components/chat-input/file-items.tsx
@@ -75,7 +75,7 @@ export function FileItem({ file, onRemove }: FileItemProps) {
             <button
               type="button"
               onClick={handleRemove}
-              className="border-background absolute top-1 right-1 z-10 inline-flex size-6 translate-x-1/2 -translate-y-1/2 items-center justify-center rounded-full border-[3px] bg-black text-white shadow-none transition-colors"
+              className="border-background/80 absolute top-1 right-1 z-10 inline-flex size-6 translate-x-1/2 -translate-y-1/2 items-center justify-center rounded-full border-[3px] bg-background text-foreground shadow-none transition-colors hover:bg-muted"
               aria-label="Remove file"
             >
               <X className="size-3" />

--- a/app/components/layout/header.tsx
+++ b/app/components/layout/header.tsx
@@ -5,14 +5,15 @@ import { AppInfoTrigger } from "@/app/components/layout/app-info/app-info-trigge
 import { ButtonNewChat } from "@/app/components/layout/button-new-chat"
 import { UserMenu } from "@/app/components/layout/user-menu"
 import { useBreakpoint } from "@/app/hooks/use-breakpoint"
-import { Button } from "@/components/ui/button"
 import { Logo } from "@/components/ui/logo"
+import { ThemeToggle } from "@/components/ui/theme-toggle"
+import { Button } from "@/components/ui/button"
 import { APP_NAME } from "@/lib/config"
 import { useUserPreferences } from "@/lib/user-preference-store/provider"
 import { useUser } from "@/lib/user-store/provider"
 import { Info } from "@phosphor-icons/react"
 import Link from "next/link"
-import { useEffect, useState } from "react"
+import { useEffect } from "react"
 import { DialogPublish } from "./dialog-publish"
 import { HeaderSidebarTrigger } from "./header-sidebar-trigger"
 
@@ -41,7 +42,7 @@ export function Header({ hasSidebar }: { hasSidebar: boolean }) {
             <div className="flex flex-1 items-center gap-2">
               <Link
                 href="/"
-                className="pointer-events-auto inline-flex items-center text-xl font-medium tracking-tight text-white"
+                className="pointer-events-auto inline-flex items-center text-xl font-medium tracking-tight text-foreground"
               >
                 <Logo size="md" variant="ascii" />
               </Link>
@@ -50,7 +51,8 @@ export function Header({ hasSidebar }: { hasSidebar: boolean }) {
           </div>
           <div />
           {!isLoggedIn ? (
-            <div className="pointer-events-auto flex flex-1 items-center justify-end gap-4">
+            <div className="pointer-events-auto flex flex-1 items-center justify-end gap-3">
+              <ThemeToggle />
               <AppInfoTrigger
                 trigger={
                   <Button
@@ -72,6 +74,7 @@ export function Header({ hasSidebar }: { hasSidebar: boolean }) {
             </div>
           ) : (
             <div className="pointer-events-auto flex flex-1 items-center justify-end gap-2">
+              <ThemeToggle />
               {!isMultiModelEnabled && <DialogPublish />}
               <ButtonNewChat />
               {!hasSidebar && <HistoryTrigger hasSidebar={hasSidebar} />}

--- a/app/components/layout/sidebar/app-sidebar.tsx
+++ b/app/components/layout/sidebar/app-sidebar.tsx
@@ -50,7 +50,11 @@ export function AppSidebar() {
       <SidebarHeader className="h-14 px-3">
         <div className="flex items-center justify-between h-full">
           <Link href="/" className="inline-flex" onClick={() => router.push("/")}>
-            <Logo size="md" variant="text" className="text-white" />
+            <Logo
+              size="md"
+              variant="text"
+              className="text-sidebar-foreground"
+            />
           </Link>
           {isMounted && isMobile && (
             <button

--- a/app/cover/page.tsx
+++ b/app/cover/page.tsx
@@ -95,8 +95,8 @@ export default function CoverPage() {
     return () => observer.disconnect()
   }, [])
   return (
-    <div className="flex flex-col items-center justify-center w-full h-screen bg-black text-white relative overflow-hidden">
-      {/* Clean black background for cover */}
+    <div className="bg-background text-foreground relative flex h-screen w-full flex-col items-center justify-center overflow-hidden">
+      {/* Theme-aware background for cover */}
 
       <div className="flex flex-col items-center justify-center space-y-[8vh] w-full h-full px-[5vw] relative z-10">
         {/* Logo */}

--- a/app/globals.css
+++ b/app/globals.css
@@ -70,25 +70,26 @@
 }
 
 :root {
-  /* Newth brand design tokens - 2025 dark-first approach */
-  --background: 0 0 0;
-  --foreground: 0 0 100%;
-  --card: rgba(255, 255, 255, 0.02);
-  --card-foreground: 0 0 100%;
-  --popover: rgba(255, 255, 255, 0.02);
-  --popover-foreground: 0 0 100%;
-  --primary: 258 90% 66%; /* Violet accent */
-  --primary-foreground: 0 0 100%;
-  --secondary: rgba(255, 255, 255, 0.05);
-  --secondary-foreground: 0 0 100%;
-  --muted: 0 0 96%;
-  --muted-foreground: 0 0 45%;
-  --accent: 258 90% 66%;
-  --accent-foreground: 0 0 100%;
-  --destructive: 0 85% 60%;
-  --destructive-foreground: 0 0 100%;
-  --border: rgba(255, 255, 255, 0.08);
-  --input: rgba(255, 255, 255, 0.08);
+  color-scheme: light;
+  /* Newth brand design tokens */
+  --background: 0 0% 100%;
+  --foreground: 222.2 47.4% 11.2%;
+  --card: 0 0% 100%;
+  --card-foreground: 222.2 47.4% 11.2%;
+  --popover: 0 0% 100%;
+  --popover-foreground: 222.2 47.4% 11.2%;
+  --primary: 258 90% 66%;
+  --primary-foreground: 0 0% 100%;
+  --secondary: 220 14.3% 95.9%;
+  --secondary-foreground: 220.9 39.3% 11%;
+  --muted: 220 14.3% 95.9%;
+  --muted-foreground: 220 8.9% 46.1%;
+  --accent: 220 14.3% 95.9%;
+  --accent-foreground: 220.9 39.3% 11%;
+  --destructive: 0 84.2% 60.2%;
+  --destructive-foreground: 0 0% 98%;
+  --border: 220 13% 91%;
+  --input: 220 13% 91%;
   --ring: 258 90% 66%;
 
   /* 2025 Iridescent color palette */
@@ -106,9 +107,9 @@
   --fluid-max-ratio: 1.333;
 
   /* Glassmorphism tokens */
-  --glass-bg: rgba(255, 255, 255, 0.02);
-  --glass-border: rgba(255, 255, 255, 0.08);
-  --glass-shadow: 0 8px 32px 0 rgba(0, 0, 0, 0.37);
+  --glass-bg: rgba(255, 255, 255, 0.85);
+  --glass-border: rgba(15, 23, 42, 0.08);
+  --glass-shadow: 0 8px 32px 0 rgba(15, 23, 42, 0.08);
 
   /* Magnetic interaction zones */
   --magnetic-strength: 30px;
@@ -119,55 +120,60 @@
   --ease-in-out-expo: cubic-bezier(0.87, 0, 0.13, 1);
 
   --chart-1: 258 90% 66%;
-  --chart-2: 0 0 100%;
-  --chart-3: 258 90% 80%;
-  --chart-4: 258 90% 50%;
-  --chart-5: 0 0 60%;
+  --chart-2: 199 89% 48%;
+  --chart-3: 142 72% 45%;
+  --chart-4: 45 93% 47%;
+  --chart-5: 12 76% 61%;
   --radius: 0.75rem;
-  --sidebar: rgba(0, 0, 0, 0.95);
-  --sidebar-foreground: 0 0 100%;
+  --sidebar: 0 0% 98%;
+  --sidebar-foreground: 222.2 47.4% 11.2%;
   --sidebar-primary: 258 90% 66%;
-  --sidebar-primary-foreground: 0 0 100%;
-  --sidebar-accent: rgba(139, 92, 246, 0.1);
-  --sidebar-accent-foreground: 0 0 100%;
-  --sidebar-border: rgba(255, 255, 255, 0.06);
+  --sidebar-primary-foreground: 0 0% 100%;
+  --sidebar-accent: 220 14.3% 95.9%;
+  --sidebar-accent-foreground: 220.9 39.3% 11%;
+  --sidebar-border: 220 13% 91%;
   --sidebar-ring: 258 90% 66%;
+  --placeholder-color: rgba(15, 23, 42, 0.4);
 }
 
 .dark {
-  /* Already dark by default - keep similar values */
-  --background: 0 0 0;
-  --foreground: 0 0 100%;
-  --card: rgba(255, 255, 255, 0.02);
-  --card-foreground: 0 0 100%;
-  --popover: rgba(255, 255, 255, 0.03);
-  --popover-foreground: 0 0 100%;
+  color-scheme: dark;
+  --background: 240 10% 3.9%;
+  --foreground: 0 0% 98%;
+  --card: 240 10% 3.9%;
+  --card-foreground: 0 0% 98%;
+  --popover: 240 10% 3.9%;
+  --popover-foreground: 0 0% 98%;
   --primary: 258 90% 66%;
-  --primary-foreground: 0 0 100%;
-  --secondary: rgba(255, 255, 255, 0.05);
-  --secondary-foreground: 0 0 100%;
-  --muted: rgba(255, 255, 255, 0.1);
-  --muted-foreground: rgba(255, 255, 255, 0.6);
-  --accent: 258 90% 66%;
-  --accent-foreground: 0 0 100%;
-  --destructive: 0 85% 60%;
-  --destructive-foreground: 0 0 100%;
-  --border: rgba(255, 255, 255, 0.08);
-  --input: rgba(255, 255, 255, 0.08);
-  --ring: rgba(139, 92, 246, 0.5);
+  --primary-foreground: 0 0% 100%;
+  --secondary: 240 3.7% 15.9%;
+  --secondary-foreground: 0 0% 98%;
+  --muted: 240 3.7% 15.9%;
+  --muted-foreground: 240 5% 64.9%;
+  --accent: 240 3.7% 15.9%;
+  --accent-foreground: 0 0% 98%;
+  --destructive: 0 62.8% 30.6%;
+  --destructive-foreground: 0 0% 98%;
+  --border: 240 3.7% 15.9%;
+  --input: 240 3.7% 15.9%;
+  --ring: 258 90% 66%;
   --chart-1: 258 90% 66%;
-  --chart-2: 0 0 100%;
-  --chart-3: 258 90% 80%;
-  --chart-4: 258 90% 50%;
-  --chart-5: 0 0 60%;
-  --sidebar: rgba(0, 0, 0, 0.95);
-  --sidebar-foreground: 0 0 100%;
+  --chart-2: 210 89% 56%;
+  --chart-3: 142 84% 45%;
+  --chart-4: 25 95% 53%;
+  --chart-5: 340 82% 67%;
+  --sidebar: 240 10% 3.9%;
+  --sidebar-foreground: 0 0% 98%;
   --sidebar-primary: 258 90% 66%;
-  --sidebar-primary-foreground: 0 0 100%;
-  --sidebar-accent: rgba(139, 92, 246, 0.1);
-  --sidebar-accent-foreground: 0 0 100%;
-  --sidebar-border: rgba(255, 255, 255, 0.06);
-  --sidebar-ring: rgba(139, 92, 246, 0.5);
+  --sidebar-primary-foreground: 0 0% 100%;
+  --sidebar-accent: 258 90% 30%;
+  --sidebar-accent-foreground: 0 0% 98%;
+  --sidebar-border: 240 4% 20%;
+  --sidebar-ring: 258 90% 66%;
+  --glass-bg: rgba(255, 255, 255, 0.05);
+  --glass-border: rgba(255, 255, 255, 0.08);
+  --glass-shadow: 0 8px 32px 0 rgba(0, 0, 0, 0.37);
+  --placeholder-color: rgba(255, 255, 255, 0.35);
 }
 
 @layer base {
@@ -176,46 +182,47 @@
   }
 
   html {
-    @apply bg-black;
+    @apply bg-background;
+    color: hsl(var(--foreground));
   }
 
   body {
-    @apply bg-black text-white antialiased;
+    @apply bg-background text-foreground antialiased;
     font-feature-settings: "rlig" 1, "calt" 1;
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;
-    background-color: #000000 !important;
+    background-color: hsl(var(--background)) !important;
   }
 
   /* Selection color */
   ::selection {
-    background: rgba(139, 92, 246, 0.3);
-    color: white;
+    background: hsl(var(--primary) / 0.25);
+    color: hsl(var(--primary-foreground));
   }
 
   /* Translucent placeholder text */
   ::placeholder {
-    color: rgba(255, 255, 255, 0.3) !important;
+    color: var(--placeholder-color) !important;
     opacity: 1 !important;
   }
 
   ::-webkit-input-placeholder {
-    color: rgba(255, 255, 255, 0.3) !important;
+    color: var(--placeholder-color) !important;
     opacity: 1 !important;
   }
 
   ::-moz-placeholder {
-    color: rgba(255, 255, 255, 0.3) !important;
+    color: var(--placeholder-color) !important;
     opacity: 1 !important;
   }
 
   :-ms-input-placeholder {
-    color: rgba(255, 255, 255, 0.3) !important;
+    color: var(--placeholder-color) !important;
     opacity: 1 !important;
   }
 
   textarea::placeholder {
-    color: rgba(255, 255, 255, 0.3) !important;
+    color: var(--placeholder-color) !important;
     opacity: 1 !important;
   }
 
@@ -234,7 +241,7 @@
 
   /* Text styling */
   strong {
-    @apply text-white font-semibold;
+    @apply text-foreground font-semibold;
     opacity: 0.95;
   }
 
@@ -634,7 +641,7 @@ code {
 .prose {
   /* Strong text styling */
   strong {
-    @apply text-white font-semibold;
+    @apply text-foreground font-semibold;
     opacity: 0.95;
   }
 
@@ -648,13 +655,13 @@ code {
   }
 
   ol li::marker {
-    @apply text-white font-medium;
+    @apply text-foreground font-medium;
     opacity: 0.9;
   }
 
   /* Better bullet list styling */
   ul li::marker {
-    @apply text-white;
+    @apply text-muted-foreground;
     opacity: 0.8;
   }
 

--- a/app/share/[chatId]/article.tsx
+++ b/app/share/[chatId]/article.tsx
@@ -54,8 +54,8 @@ export default function Article({
               className="text-muted-foreground group flex h-12 w-full max-w-36 items-center justify-between rounded-full py-2 pr-2 pl-4 shadow-sm btn-bob"
             >
               Ask Bob{" "}
-              <div className="rounded-full bg-black/20 p-2 backdrop-blur-sm transition-colors group-hover:bg-black/30">
-                <ArrowUpRight className="h-4 w-4 text-white" />
+              <div className="rounded-full bg-primary/10 p-2 backdrop-blur-sm transition-colors group-hover:bg-primary/20">
+                <ArrowUpRight className="h-4 w-4 text-primary" />
               </div>
             </Button>
           </Link>
@@ -78,7 +78,7 @@ export default function Article({
                   <MessageContent
                     markdown={true}
                     className={cn(
-                      message.role === "user" && "bg-blue-600 text-white",
+                      message.role === "user" && "bg-primary text-primary-foreground",
                       message.role === "assistant" &&
                         "w-full min-w-full bg-transparent",
                       "prose-h1:scroll-m-20 prose-h1:text-2xl prose-h1:font-semibold prose-h2:mt-8 prose-h2:scroll-m-20 prose-h2:text-xl prose-h2:mb-3 prose-h2:font-medium prose-h3:scroll-m-20 prose-h3:text-base prose-h3:font-medium prose-h4:scroll-m-20 prose-h5:scroll-m-20 prose-h6:scroll-m-20 prose-strong:font-medium prose-table:block prose-table:overflow-y-auto"

--- a/components/ui/theme-toggle.tsx
+++ b/components/ui/theme-toggle.tsx
@@ -1,0 +1,147 @@
+"use client"
+
+import { useEffect, useMemo, useState } from "react"
+import { Button } from "@/components/ui/button"
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu"
+import { cn } from "@/lib/utils"
+import { useUserPreferences, type ThemeType } from "@/lib/user-preference-store/provider"
+import { Check, Desktop, Moon, Sun } from "@phosphor-icons/react"
+import { useTheme } from "next-themes"
+
+const THEME_OPTIONS: Array<{
+  id: ThemeType
+  label: string
+  description: string
+  icon: typeof Sun
+}> = [
+  {
+    id: "system",
+    label: "System",
+    description: "Match device settings",
+    icon: Desktop,
+  },
+  {
+    id: "light",
+    label: "Light",
+    description: "Bright background, dark text",
+    icon: Sun,
+  },
+  {
+    id: "dark",
+    label: "Dark",
+    description: "Dimmed background, light text",
+    icon: Moon,
+  },
+]
+
+function isThemeType(value?: string | null): value is ThemeType {
+  return value === "light" || value === "dark" || value === "system"
+}
+
+export function ThemeToggle({ className }: { className?: string }) {
+  const { preferences, setTheme: setUserTheme } = useUserPreferences()
+  const { theme, resolvedTheme, setTheme } = useTheme()
+  const [mounted, setMounted] = useState(false)
+
+  useEffect(() => {
+    setMounted(true)
+  }, [])
+
+  useEffect(() => {
+    if (!mounted) return
+    if (preferences.theme !== theme) {
+      setTheme(preferences.theme)
+    }
+  }, [mounted, preferences.theme, setTheme, theme])
+
+  const activeThemeId = useMemo<ThemeType>(() => {
+    if (isThemeType(theme)) {
+      return theme
+    }
+    return preferences.theme
+  }, [preferences.theme, theme])
+
+  const handleThemeChange = (value: ThemeType) => {
+    setUserTheme(value)
+    setTheme(value)
+  }
+
+  if (!mounted) {
+    return (
+      <Button
+        variant="ghost"
+        size="icon"
+        className={cn(
+          "relative h-9 w-9 rounded-full",
+          "bg-muted text-muted-foreground",
+          className
+        )}
+        aria-label="Loading theme toggle"
+        disabled
+      >
+        <Sun className="size-4 animate-pulse opacity-70" />
+      </Button>
+    )
+  }
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button
+          variant="ghost"
+          size="icon"
+          className={cn(
+            "relative h-9 w-9 rounded-full border border-border",
+            "bg-background text-foreground hover:bg-muted",
+            className
+          )}
+          aria-label="Toggle theme"
+        >
+          <Sun
+            className={cn(
+              "size-4 rotate-0 scale-100 transition-all",
+              resolvedTheme === "dark" && "-rotate-90 scale-0"
+            )}
+          />
+          <Moon
+            className={cn(
+              "absolute size-4 rotate-90 scale-0 transition-all",
+              resolvedTheme === "dark" && "rotate-0 scale-100"
+            )}
+          />
+          {activeThemeId === "system" ? (
+            <Desktop className="absolute bottom-1 right-1 size-3 text-muted-foreground" />
+          ) : null}
+          <span className="sr-only">Toggle theme</span>
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end" className="w-48">
+        {THEME_OPTIONS.map((option) => (
+          <DropdownMenuItem
+            key={option.id}
+            onClick={() => handleThemeChange(option.id)}
+            className="flex items-start gap-3 px-3 py-2"
+          >
+            <div className="mt-0.5">
+              <option.icon className="size-4" />
+            </div>
+            <div className="flex flex-1 flex-col text-left">
+              <span className="text-sm font-medium">{option.label}</span>
+              <span className="text-xs text-muted-foreground">
+                {option.description}
+              </span>
+            </div>
+            {activeThemeId === option.id ? (
+              <Check className="size-4 text-primary" />
+            ) : null}
+          </DropdownMenuItem>
+        ))}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  )
+}

--- a/lib/providers/app-provider.tsx
+++ b/lib/providers/app-provider.tsx
@@ -36,9 +36,10 @@ export function AppProvider({ children, userProfile }: AppProviderProps) {
                   >
                     <ThemeProvider
                       attribute="class"
-                      defaultTheme="light"
+                      defaultTheme="system"
                       enableSystem
                       disableTransitionOnChange
+                      storageKey="bob-theme"
                     >
                       <SidebarProvider defaultOpen={false}>
                         <Toaster position="top-center" />

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -3,6 +3,7 @@ import type { Config } from 'tailwindcss'
 import tailwindcssAnimate from 'tailwindcss-animate'
 
 const config: Config = {
+  darkMode: 'class',
   content: [
     './pages/**/*.{js,ts,jsx,tsx,mdx}',
     './components/**/*.{js,ts,jsx,tsx,mdx}',

--- a/tests/utils/visual-testing.ts
+++ b/tests/utils/visual-testing.ts
@@ -56,7 +56,7 @@ export class VisualTestingUtils {
     // Enable dark mode
     await this.page.evaluate(() => {
       document.documentElement.classList.add('dark')
-      localStorage.setItem('theme', 'dark')
+      localStorage.setItem('bob-theme', 'dark')
     })
 
     await this.page.waitForTimeout(500) // Wait for theme transition

--- a/tests/visual/components.spec.ts
+++ b/tests/visual/components.spec.ts
@@ -90,7 +90,7 @@ test.describe('Visual Regression Tests', () => {
     } else {
       // Force dark mode via localStorage
       await page.evaluate(() => {
-        localStorage.setItem('theme', 'dark')
+        localStorage.setItem('bob-theme', 'dark')
         document.documentElement.classList.add('dark')
       })
       await page.reload()


### PR DESCRIPTION
## Summary
- add a reusable theme toggle dropdown that syncs with stored preferences and expose it in the header for quick switching
- update theme provider, design tokens, and several UI surfaces to support light/dark palettes based on system or manual selection
- adjust automated tests and Tailwind dark mode handling to honor the new persisted theme key

## Testing
- npm run lint *(fails: existing lint debt in repository)*
- npm run type-check

------
https://chatgpt.com/codex/tasks/task_e_68d39a6e046c832a8df321784816d483