### PR TITLE
Improve chat accessibility and ARIA support

### DIFF
--- a/app/components/chat-input/button-search.tsx
+++ b/app/components/chat-input/button-search.tsx
@@ -28,6 +28,8 @@ export function ButtonSearch({
           <Button
             variant="secondary"
             className="border-border dark:bg-secondary rounded-full border bg-transparent"
+            type="button"
+            aria-label="Enable web search"
           >
             <GlobeIcon className="size-5" />
             Search
@@ -47,6 +49,9 @@ export function ButtonSearch({
           "border-[#0091FF]/20 bg-[#E5F3FE] text-[#0091FF] hover:bg-[#E5F3FE] hover:text-[#0091FF]"
       )}
       onClick={handleClick}
+      aria-pressed={isSelected}
+      aria-label={isSelected ? "Disable web search" : "Enable web search"}
+      type="button"
     >
       <GlobeIcon className="size-5" />
       <span className="hidden md:block">Search</span>

--- a/app/components/chat-input/chat-input.tsx
+++ b/app/components/chat-input/chat-input.tsx
@@ -197,6 +197,7 @@ export function ChatInput({
             className="min-h-[44px] pt-3 pl-4 text-base leading-[1.3] sm:text-base md:text-base"
             aria-invalid={isErrored}
             aria-describedby={errorMessageId}
+            aria-label="Message input"
           />
           <PromptInputActions className="mt-3 w-full justify-between p-2">
             <div className="flex gap-2">

--- a/app/components/chat-input/file-items.tsx
+++ b/app/components/chat-input/file-items.tsx
@@ -34,7 +34,10 @@ export function FileItem({ file, onRemove }: FileItemProps) {
         open={file.type.includes("image") ? isOpen : false}
         onOpenChange={setIsOpen}
       >
-        <HoverCardTrigger className="w-full">
+        <HoverCardTrigger
+          className="w-full"
+          aria-label={`Attached file ${file.name}`}
+        >
           <div className="bg-background hover:bg-accent border-input flex w-full items-center gap-3 rounded-2xl border p-2 pr-3 transition-colors">
             <div className="bg-accent-foreground flex h-10 w-10 flex-shrink-0 items-center justify-center overflow-hidden rounded-md">
               {file.type.includes("image") ? (
@@ -75,7 +78,7 @@ export function FileItem({ file, onRemove }: FileItemProps) {
             <button
               type="button"
               onClick={handleRemove}
-              className="border-background absolute top-1 right-1 z-10 inline-flex size-6 translate-x-1/2 -translate-y-1/2 items-center justify-center rounded-full border-[3px] bg-black text-white shadow-none transition-colors"
+              className="border-background absolute top-1 right-1 z-10 inline-flex size-6 translate-x-1/2 -translate-y-1/2 items-center justify-center rounded-full border-[3px] bg-black text-white shadow-none transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ring"
               aria-label="Remove file"
             >
               <X className="size-3" />

--- a/app/components/chat-input/file-list.tsx
+++ b/app/components/chat-input/file-list.tsx
@@ -24,7 +24,11 @@ export function FileList({ files, onFileRemove }: FileListProps) {
           transition={TRANSITION}
           className="overflow-hidden"
         >
-          <div className="flex flex-row overflow-x-auto pl-3">
+          <div
+            className="flex flex-row overflow-x-auto pl-3"
+            role="list"
+            aria-live="polite"
+          >
             <AnimatePresence initial={false}>
               {files.map((file) => (
                 <motion.div
@@ -34,6 +38,7 @@ export function FileList({ files, onFileRemove }: FileListProps) {
                   exit={{ width: 0 }}
                   transition={TRANSITION}
                   className="relative shrink-0 overflow-hidden pt-2"
+                  role="listitem"
                 >
                   <FileItem
                     key={file.name}

--- a/app/components/chat/chat.tsx
+++ b/app/components/chat/chat.tsx
@@ -236,8 +236,8 @@ export function Chat() {
   if (shouldRedirect && isFetchingOrWillFetch) {
     // The effect will trigger fetchChatDirectly, so we just show loading
     return (
-      <div className="flex h-full items-center justify-center">
-        <div className="text-center">
+      <div className="flex h-full items-center justify-center" role="status" aria-live="polite">
+        <div className="text-center" aria-busy="true">
           <div className="h-8 w-8 animate-spin rounded-full border-4 border-primary border-t-transparent mx-auto mb-2"></div>
           <p className="text-muted-foreground">Loading automation chat...</p>
         </div>
@@ -275,6 +275,9 @@ export function Chat() {
             transition={{
               duration: 0.2,
             }}
+            role="status"
+            aria-live="polite"
+            aria-busy="true"
           >
             <div className="text-center">
               <div className="h-8 w-8 animate-spin rounded-full border-4 border-primary border-t-transparent mx-auto mb-4"></div>
@@ -288,7 +291,7 @@ export function Chat() {
           </motion.div>
         ) : hasMessages ? (
           <Conversation key="conversation" {...conversationProps} />
-        ) : (
+        ) : showOnboarding ? (
           <motion.div
             key="onboarding"
             className="mx-auto max-w-[50rem] mb-8"
@@ -304,7 +307,7 @@ export function Chat() {
               What&apos;s on your mind?
             </h1>
           </motion.div>
-        )}
+        ) : null}
       </AnimatePresence>
 
       <div

--- a/app/components/chat/conversation.tsx
+++ b/app/components/chat/conversation.tsx
@@ -31,12 +31,20 @@ export function Conversation({
     return null
 
   return (
-    <div className="relative flex h-full w-full flex-col items-center overflow-hidden">
+    <section
+      className="relative flex h-full w-full flex-col items-center overflow-hidden"
+      aria-label="Conversation history"
+    >
       <div className="pointer-events-none absolute top-0 right-0 left-0 z-20 mx-auto flex w-full flex-col justify-center">
         <div className="h-[56px] bg-background flex w-full" />
         <div className="h-4 bg-gradient-to-b from-background to-transparent flex w-full" />
       </div>
-      <ChatContainerRoot className="relative w-full h-full overflow-y-auto overflow-x-hidden">
+      <ChatContainerRoot
+        className="relative h-full w-full overflow-y-auto overflow-x-hidden focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ring"
+        tabIndex={0}
+        aria-label="Conversation messages"
+        aria-busy={status === "streaming"}
+      >
         <ChatContainerContent
           className="flex w-full flex-col items-center pt-32 pb-4"
           style={{
@@ -44,43 +52,54 @@ export function Conversation({
             scrollbarWidth: "none",
           }}
         >
-          {messages?.map((message, index) => {
-            const isLast =
-              index === messages.length - 1 && status !== "submitted"
-            const hasScrollAnchor =
-              isLast && messages.length > initialMessageCount.current
+          <ol className="mx-auto flex w-full list-none flex-col items-center gap-0 pb-4 pl-0 pr-0">
+            {messages?.map((message, index) => {
+              const isLast =
+                index === messages.length - 1 && status !== "submitted"
+              const hasScrollAnchor =
+                isLast && messages.length > initialMessageCount.current
 
-            return (
-              <Message
-                key={message.id}
-                id={message.id}
-                variant={message.role}
-                attachments={message.experimental_attachments}
-                isLast={isLast}
-                onDelete={onDelete}
-                onEdit={onEdit}
-                onReload={onReload}
-                hasScrollAnchor={hasScrollAnchor}
-                parts={message.parts}
-                status={status}
-                onQuote={onQuote}
-              >
-                {message.content}
-              </Message>
-            )
-          })}
-          {status === "submitted" &&
-            messages.length > 0 &&
-            messages[messages.length - 1].role === "user" && (
-              <div className="group min-h-scroll-anchor flex w-full max-w-3xl flex-col items-start gap-2 px-6 pb-2">
-                <Loader />
-              </div>
-            )}
-          <div className="absolute bottom-0 flex w-full max-w-3xl flex-1 items-end justify-end gap-4 px-6 pb-2">
-            <ScrollButton className="absolute top-[-50px] right-[30px]" />
+              return (
+                <li key={message.id} className="w-full list-none">
+                  <Message
+                    id={message.id}
+                    variant={message.role}
+                    attachments={message.experimental_attachments}
+                    isLast={isLast}
+                    onDelete={onDelete}
+                    onEdit={onEdit}
+                    onReload={onReload}
+                    hasScrollAnchor={hasScrollAnchor}
+                    parts={message.parts}
+                    status={status}
+                    onQuote={onQuote}
+                  >
+                    {message.content}
+                  </Message>
+                </li>
+              )
+            })}
+            {status === "submitted" &&
+              messages.length > 0 &&
+              messages[messages.length - 1].role === "user" && (
+                <li
+                  className="group min-h-scroll-anchor flex w-full max-w-3xl list-none flex-col items-start gap-2 px-6 pb-2"
+                  role="status"
+                  aria-live="polite"
+                >
+                  <span className="sr-only">Assistant is responding</span>
+                  <Loader />
+                </li>
+              )}
+          </ol>
+          <div className="pointer-events-none absolute bottom-0 flex w-full max-w-3xl flex-1 items-end justify-end gap-4 px-6 pb-2">
+            <ScrollButton
+              className="pointer-events-auto absolute right-[30px] top-[-50px]"
+              aria-label="Scroll to latest messages"
+            />
           </div>
         </ChatContainerContent>
       </ChatContainerRoot>
-    </div>
+    </section>
   )
 }

--- a/app/components/chat/message-assistant.tsx
+++ b/app/components/chat/message-assistant.tsx
@@ -117,15 +117,21 @@ export function MessageAssistant({
         )}
 
         {contentNullOrEmpty ? null : (
-          <MessageContent
-            className={cn(
-              "prose dark:prose-invert relative min-w-full bg-transparent p-0",
-              "prose-h1:scroll-m-20 prose-h1:text-2xl prose-h1:font-semibold prose-h2:mt-8 prose-h2:scroll-m-20 prose-h2:text-xl prose-h2:mb-3 prose-h2:font-medium prose-h3:scroll-m-20 prose-h3:text-base prose-h3:font-medium prose-h4:scroll-m-20 prose-h5:scroll-m-20 prose-h6:scroll-m-20 prose-strong:font-medium prose-table:block prose-table:overflow-y-auto"
-            )}
-            markdown={true}
-          >
-            {children}
-          </MessageContent>
+          <>
+            <span className="sr-only" aria-hidden="false">
+              Assistant responded:
+            </span>
+            <MessageContent
+              className={cn(
+                "prose dark:prose-invert relative min-w-full bg-transparent p-0",
+                "prose-h1:scroll-m-20 prose-h1:text-2xl prose-h1:font-semibold prose-h2:mt-8 prose-h2:scroll-m-20 prose-h2:text-xl prose-h2:mb-3 prose-h2:font-medium prose-h3:scroll-m-20 prose-h3:text-base prose-h3:font-medium prose-h4:scroll-m-20 prose-h5:scroll-m-20 prose-h6:scroll-m-20 prose-strong:font-medium prose-table:block prose-table:overflow-y-auto"
+              )}
+              markdown={true}
+              aria-live={isLastStreaming ? "polite" : undefined}
+            >
+              {children}
+            </MessageContent>
+          </>
         )}
 
         {sources && sources.length > 0 && <SourcesList sources={sources} />}
@@ -141,7 +147,7 @@ export function MessageAssistant({
               side="bottom"
             >
               <button
-                className="hover:bg-accent/60 text-muted-foreground hover:text-foreground flex size-7.5 items-center justify-center rounded-full bg-transparent transition"
+                className="flex size-7.5 items-center justify-center rounded-full bg-transparent text-muted-foreground transition hover:bg-accent/60 hover:text-foreground focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ring"
                 aria-label="Copy text"
                 onClick={copyToClipboard}
                 type="button"
@@ -160,7 +166,7 @@ export function MessageAssistant({
                 delayDuration={0}
               >
                 <button
-                  className="hover:bg-accent/60 text-muted-foreground hover:text-foreground flex size-7.5 items-center justify-center rounded-full bg-transparent transition"
+                  className="flex size-7.5 items-center justify-center rounded-full bg-transparent text-muted-foreground transition hover:bg-accent/60 hover:text-foreground focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ring"
                   aria-label="Regenerate"
                   onClick={onReload}
                   type="button"

--- a/app/components/chat/message-user.tsx
+++ b/app/components/chat/message-user.tsx
@@ -80,48 +80,60 @@ export function MessageUser({
         className
       )}
     >
-      {attachments?.map((attachment, index) => (
-        <div
-          className="flex flex-row gap-2"
-          key={`${attachment.name}-${index}`}
-        >
-          {attachment.contentType?.startsWith("image") ? (
-            <MorphingDialog
-              transition={{
-                type: "spring" as const,
-                stiffness: 280,
-                damping: 18,
-                mass: 0.3,
-              }}
+      {attachments && attachments.length > 0 ? (
+        <div className="flex w-full flex-col items-end gap-2" role="list">
+          {attachments.map((attachment, index) => (
+            <div
+              className="flex flex-row gap-2"
+              key={`${attachment.name}-${index}`}
+              role="listitem"
             >
-              <MorphingDialogTrigger className="z-10">
-                <Image
-                  className="mb-1 w-40 rounded-md"
-                  key={attachment.name}
-                  src={attachment.url}
-                  alt={attachment.name || "Attachment"}
-                  width={160}
-                  height={120}
-                />
-              </MorphingDialogTrigger>
-              <MorphingDialogContainer>
-                <MorphingDialogContent className="relative rounded-lg">
-                  <MorphingDialogImage
-                    src={attachment.url}
-                    alt={attachment.name || ""}
-                    className="max-h-[90vh] max-w-[90vw] object-contain"
-                  />
-                </MorphingDialogContent>
-                <MorphingDialogClose className="text-primary" />
-              </MorphingDialogContainer>
-            </MorphingDialog>
-          ) : attachment.contentType?.startsWith("text") ? (
-            <div className="text-primary mb-3 h-24 w-40 overflow-hidden rounded-md border p-2 text-xs">
-              {getTextFromDataUrl(attachment.url)}
+              {attachment.contentType?.startsWith("image") ? (
+                <MorphingDialog
+                  transition={{
+                    type: "spring" as const,
+                    stiffness: 280,
+                    damping: 18,
+                    mass: 0.3,
+                  }}
+                >
+                  <MorphingDialogTrigger
+                    className="z-10"
+                    ariaLabel={`View image attachment ${attachment.name ?? ""}`.trim()}
+                  >
+                    <Image
+                      className="mb-1 w-40 rounded-md"
+                      key={attachment.name}
+                      src={attachment.url}
+                      alt={attachment.name || "Attachment"}
+                      width={160}
+                      height={120}
+                    />
+                  </MorphingDialogTrigger>
+                  <MorphingDialogContainer>
+                    <MorphingDialogContent className="relative rounded-lg">
+                      <MorphingDialogImage
+                        src={attachment.url}
+                        alt={attachment.name || ""}
+                        className="max-h-[90vh] max-w-[90vw] object-contain"
+                      />
+                    </MorphingDialogContent>
+                    <MorphingDialogClose className="text-primary" />
+                  </MorphingDialogContainer>
+                </MorphingDialog>
+              ) : attachment.contentType?.startsWith("text") ? (
+                <div
+                  className="text-primary mb-3 h-24 w-40 overflow-hidden rounded-md border p-2 text-xs"
+                  role="img"
+                  aria-label={attachment.name || "Text attachment"}
+                >
+                  {getTextFromDataUrl(attachment.url)}
+                </div>
+              ) : null}
             </div>
-          ) : null}
+          ))}
         </div>
-      ))}
+      ) : null}
       {isEditing ? (
         <div
           className="bg-accent relative flex min-w-[180px] flex-col gap-2 rounded-3xl px-5 py-2.5"
@@ -143,6 +155,7 @@ export function MessageUser({
               }
             }}
             autoFocus
+            aria-label="Edit your message"
           />
           <div className="flex justify-end gap-2">
             <Button size="sm" variant="ghost" onClick={handleEditCancel}>
@@ -154,32 +167,37 @@ export function MessageUser({
           </div>
         </div>
       ) : (
-        <MessageContent
-          className="bg-accent prose dark:prose-invert relative max-w-[70%] rounded-3xl px-5 py-2.5"
-          markdown={true}
-          ref={contentRef}
-          components={{
-            code: ({ children }) => <>{children}</>,
-            pre: ({ children }) => <>{children}</>,
-            h1: ({ children }) => <p>{children}</p>,
-            h2: ({ children }) => <p>{children}</p>,
-            h3: ({ children }) => <p>{children}</p>,
-            h4: ({ children }) => <p>{children}</p>,
-            h5: ({ children }) => <p>{children}</p>,
-            h6: ({ children }) => <p>{children}</p>,
-            p: ({ children }) => <p>{children}</p>,
-            li: ({ children }) => <p>- {children}</p>,
-            ul: ({ children }) => <>{children}</>,
-            ol: ({ children }) => <>{children}</>,
-          }}
-        >
-          {children}
-        </MessageContent>
+        <>
+          <span className="sr-only" aria-hidden="false">
+            You said:
+          </span>
+          <MessageContent
+            className="bg-accent prose dark:prose-invert relative max-w-[70%] rounded-3xl px-5 py-2.5"
+            markdown={true}
+            ref={contentRef}
+            components={{
+              code: ({ children }) => <>{children}</>,
+              pre: ({ children }) => <>{children}</>,
+              h1: ({ children }) => <p>{children}</p>,
+              h2: ({ children }) => <p>{children}</p>,
+              h3: ({ children }) => <p>{children}</p>,
+              h4: ({ children }) => <p>{children}</p>,
+              h5: ({ children }) => <p>{children}</p>,
+              h6: ({ children }) => <p>{children}</p>,
+              p: ({ children }) => <p>{children}</p>,
+              li: ({ children }) => <p>- {children}</p>,
+              ul: ({ children }) => <>{children}</>,
+              ol: ({ children }) => <>{children}</>,
+            }}
+          >
+            {children}
+          </MessageContent>
+        </>
       )}
       <MessageActions className="flex gap-0 opacity-0 transition-opacity duration-0 group-hover:opacity-100">
         <MessageAction tooltip={copied ? "Copied!" : "Copy text"} side="bottom">
           <button
-            className="hover:bg-accent/60 text-muted-foreground hover:text-foreground flex size-7.5 items-center justify-center rounded-full bg-transparent transition"
+            className="flex size-7.5 items-center justify-center rounded-full bg-transparent text-muted-foreground transition hover:bg-accent/60 hover:text-foreground focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ring"
             aria-label="Copy text"
             onClick={copyToClipboard}
             type="button"
@@ -208,7 +226,7 @@ export function MessageUser({
         </MessageAction> */}
         <MessageAction tooltip="Delete" side="bottom">
           <button
-            className="hover:bg-accent/60 text-muted-foreground hover:text-foreground flex size-7.5 items-center justify-center rounded-full bg-transparent transition"
+            className="flex size-7.5 items-center justify-center rounded-full bg-transparent text-muted-foreground transition hover:bg-accent/60 hover:text-foreground focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ring"
             aria-label="Delete"
             onClick={handleDelete}
             type="button"

--- a/app/components/chat/sources-list.tsx
+++ b/app/components/chat/sources-list.tsx
@@ -5,7 +5,7 @@ import type { SourceUIPart } from "@ai-sdk/ui-utils"
 import { CaretDown, Link } from "@phosphor-icons/react"
 import { AnimatePresence, motion } from "motion/react"
 import Image from "next/image"
-import { useState } from "react"
+import { useId, useState } from "react"
 import { addUTM, formatUrl, getFavicon } from "./utils"
 
 type SourcesListProps = {
@@ -22,6 +22,7 @@ const TRANSITION = {
 export function SourcesList({ sources, className }: SourcesListProps) {
   const [isExpanded, setIsExpanded] = useState(false)
   const [failedFavicons, setFailedFavicons] = useState<Set<string>>(new Set())
+  const listId = useId()
 
   const handleFaviconError = (url: string) => {
     setFailedFavicons((prev) => new Set(prev).add(url))
@@ -34,6 +35,8 @@ export function SourcesList({ sources, className }: SourcesListProps) {
           onClick={() => setIsExpanded(!isExpanded)}
           type="button"
           className="hover:bg-accent flex w-full flex-row items-center rounded-t-md px-3 py-2 transition-colors"
+          aria-expanded={isExpanded}
+          aria-controls={isExpanded ? listId : undefined}
         >
           <div className="flex flex-1 flex-row items-center gap-2 text-left text-sm">
             Sources
@@ -83,6 +86,7 @@ export function SourcesList({ sources, className }: SourcesListProps) {
               exit={{ height: 0, opacity: 0 }}
               transition={TRANSITION}
               className="overflow-hidden"
+              id={listId}
             >
               <ul className="space-y-2 px-3 pt-3 pb-3">
                 {sources.map((source) => {

--- a/app/components/multi-chat/multi-conversation.tsx
+++ b/app/components/multi-chat/multi-conversation.tsx
@@ -78,10 +78,11 @@ function ResponseCard({ response, group }: ResponseCardProps) {
             {response.message.content}
           </Message>
         ) : response.isLoading ? (
-          <div className="space-y-2">
+          <div className="space-y-2" role="status" aria-live="polite" aria-busy="true">
             <div className="text-muted-foreground text-xs font-medium tracking-wide uppercase">
               assistant
             </div>
+            <span className="sr-only">{model?.name} response loading</span>
             <Loader />
           </div>
         ) : (
@@ -117,9 +118,18 @@ export function MultiModelConversation({
     setGroupResponses(updated)
   }, [messageGroups])
 
+  const isStreaming = messageGroups.some((group) =>
+    group.responses.some((response) => response.isLoading)
+  )
+
   return (
-    <div className="relative flex h-full w-full flex-col items-center overflow-y-auto">
-      <ChatContainerRoot className="relative w-full">
+    <section className="relative flex h-full w-full flex-col items-center overflow-y-auto" aria-label="Multi-model conversation">
+      <ChatContainerRoot
+        className="relative w-full"
+        tabIndex={0}
+        aria-label="Multi-model conversation messages"
+        aria-busy={isStreaming}
+      >
         <ChatContainerContent
           className="flex w-full flex-col items-center pt-20 pb-[134px]"
           style={{
@@ -189,6 +199,6 @@ export function MultiModelConversation({
           </div>
         </ChatContainerContent>
       </ChatContainerRoot>
-    </div>
+    </section>
   )
 }

--- a/components/motion-primitives/morphing-dialog.tsx
+++ b/components/motion-primitives/morphing-dialog.tsx
@@ -89,6 +89,7 @@ export type MorphingDialogTriggerProps = {
   className?: string
   style?: React.CSSProperties
   triggerRef?: React.RefObject<HTMLButtonElement>
+  ariaLabel?: string
 }
 
 function MorphingDialogTrigger({
@@ -96,6 +97,7 @@ function MorphingDialogTrigger({
   className,
   style,
   triggerRef,
+  ariaLabel,
 }: MorphingDialogTriggerProps) {
   const { setIsOpen, isOpen, uniqueId } = useMorphingDialog()
 
@@ -117,14 +119,17 @@ function MorphingDialogTrigger({
     <motion.button
       ref={triggerRef}
       layoutId={`dialog-${uniqueId}`}
-      className={cn("relative", className)}
+      className={cn(
+        "relative focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ring",
+        className
+      )}
       onClick={handleClick}
       onKeyDown={handleKeyDown}
       style={style}
       aria-haspopup="dialog"
       aria-expanded={isOpen}
       aria-controls={`motion-ui-morphing-dialog-content-${uniqueId}`}
-      aria-label={`Open dialog ${uniqueId}`}
+      aria-label={ariaLabel ?? `Open dialog ${uniqueId}`}
     >
       {children}
     </motion.button>

--- a/components/prompt-kit/chat-container.tsx
+++ b/components/prompt-kit/chat-container.tsx
@@ -23,13 +23,21 @@ function ChatContainerRoot({
   className,
   ...props
 }: ChatContainerRootProps) {
+  const {
+    ["aria-live"]: ariaLive = "polite",
+    ["aria-relevant"]: ariaRelevant = "additions text",
+    ...rest
+  } = props
+
   return (
     <StickToBottom
       className={cn("flex overflow-y-auto", className)}
       resize="smooth"
       initial="smooth"
       role="log"
-      {...props}
+      aria-live={ariaLive}
+      aria-relevant={ariaRelevant}
+      {...rest}
     >
       {children}
     </StickToBottom>

--- a/components/prompt-kit/scroll-button.tsx
+++ b/components/prompt-kit/scroll-button.tsx
@@ -19,20 +19,24 @@ function ScrollButton({
   ...props
 }: ScrollButtonProps) {
   const { isAtBottom, scrollToBottom } = useStickToBottomContext()
+  const { ["aria-label"]: ariaLabel = "Scroll to latest messages", ...rest } =
+    props
 
   return (
     <Button
       variant={variant}
       size={size}
       className={cn(
-        "h-10 w-10 rounded-full transition-all duration-150 ease-out",
+        "h-10 w-10 rounded-full transition-all duration-150 ease-out focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ring",
         !isAtBottom
           ? "translate-y-0 scale-100 opacity-100"
           : "pointer-events-none translate-y-4 scale-95 opacity-0",
         className
       )}
       onClick={() => scrollToBottom()}
-      {...props}
+      type="button"
+      aria-label={ariaLabel}
+      {...rest}
     >
       <ChevronDown className="h-5 w-5" />
     </Button>


### PR DESCRIPTION
## Summary
- add semantic structure, focus treatment, and live regions to the chat log and scroll controls so screen readers receive timely updates
- enrich assistant and user message rendering with screen-reader context, accessible attachments, and keyboard-visible action affordances
- update chat input utilities, file management, and supplemental panels with ARIA labels and roles for consistent navigation across single and multi-model experiences

## Testing
- npm run lint *(fails: existing repository lint debt in unrelated files)*
- npx eslint app/components/chat/message-user.tsx app/components/chat/message-assistant.tsx app/components/chat/conversation.tsx app/components/chat/chat.tsx app/components/chat-input/button-search.tsx app/components/chat-input/chat-input.tsx app/components/chat-input/file-list.tsx app/components/chat-input/file-items.tsx app/components/chat/sources-list.tsx app/components/multi-chat/multi-conversation.tsx components/motion-primitives/morphing-dialog.tsx components/prompt-kit/chat-container.tsx components/prompt-kit/scroll-button.tsx
- npm run type-check

------
https://chatgpt.com/codex/tasks/task_e_68d39a598f70832aa42b1e78e164fd7e