### PR TITLE
fix: clarify guest chat authentication messaging

### DIFF
--- a/app/components/chat-input/chat-input.tsx
+++ b/app/components/chat-input/chat-input.tsx
@@ -9,8 +9,10 @@ import {
 } from "@/components/prompt-kit/prompt-input"
 import { Button } from "@/components/ui/button"
 import { getModelInfo } from "@/lib/models"
+import { isSupabaseEnabled } from "@/lib/supabase/config"
 import { ArrowUpIcon, StopIcon } from "@phosphor-icons/react"
 import { useCallback, useEffect, useMemo, useRef } from "react"
+import Link from "next/link"
 import { PromptSystem } from "../suggestions/prompt-system"
 import { ButtonFileUpload } from "./button-file-upload"
 import { ButtonSearch } from "./button-search"
@@ -55,6 +57,7 @@ export function ChatInput({
   setEnableSearch,
   enableSearch,
   quotedText,
+  hasMessages,
 }: ChatInputProps) {
   const selectModelConfig = getModelInfo(selectedModel)
   const hasSearchSupport = Boolean(selectModelConfig?.webSearch)
@@ -63,6 +66,10 @@ export function ChatInput({
 
   // Fix hydration mismatch by using client-side state
   const placeholder = "Ask Bob..."
+
+  const hasAnyMessages = Boolean(hasMessages)
+  const shouldShowAuthReminder =
+    isSupabaseEnabled && !isUserAuthenticated && !hasAnyMessages
 
   const hasInput = value.length > 0 && !isOnlyWhitespace(value)
   const isStreaming = status === "streaming"
@@ -188,6 +195,26 @@ export function ChatInput({
           value={value}
           onValueChange={onValueChange}
         >
+          {shouldShowAuthReminder ? (
+            <div
+              className="border-white/15 bg-white/5 text-white/80 mb-2 flex flex-col gap-3 rounded-2xl border px-4 py-3 text-sm sm:flex-row sm:items-center sm:justify-between"
+              role="status"
+              aria-live="polite"
+            >
+              <span className="text-left">
+                <span className="text-white font-medium">You&apos;re chatting as a guest.</span>{" "}
+                Sign in to save your conversations and unlock higher daily limits.
+              </span>
+              <Button
+                asChild
+                variant="secondary"
+                size="sm"
+                className="w-full sm:w-auto"
+              >
+                <Link href="/auth">Sign in to continue</Link>
+              </Button>
+            </div>
+          ) : null}
           <FileList files={files} onFileRemove={onFileRemove} />
           <PromptInputTextarea
             ref={textareaRef}

--- a/app/p/[projectId]/project-view.tsx
+++ b/app/p/[projectId]/project-view.tsx
@@ -329,6 +329,8 @@ export function ProjectView({ projectId }: ProjectViewProps) {
     [messages, status, handleDelete, handleEdit, handleReload]
   )
 
+  const hasMessages = messages.length > 0
+
   // Memoize the chat input props
   const chatInputProps = useMemo(
     () => ({
@@ -348,6 +350,7 @@ export function ProjectView({ projectId }: ProjectViewProps) {
       status,
       setEnableSearch,
       enableSearch,
+      hasMessages,
     }),
     [
       input,
@@ -364,6 +367,7 @@ export function ProjectView({ projectId }: ProjectViewProps) {
       status,
       setEnableSearch,
       enableSearch,
+      hasMessages,
     ]
   )
 


### PR DESCRIPTION
## Summary
- show an onboarding note for guests explaining sign-in benefits
- surface a chat input banner with a sign-in call to action for anonymous users
- pass chat history state into chat input consumers so the banner only shows on fresh chats

## Testing
- npm run lint *(fails: repository currently has pre-existing lint violations across API and test files)*
- npm run type-check

------
https://chatgpt.com/codex/tasks/task_e_68d39a06eeb4832abbd6d8067843dd48