### PR TITLE
feat: default to dark theme

### DIFF
--- a/app/components/layout/header.tsx
+++ b/app/components/layout/header.tsx
@@ -6,7 +6,6 @@ import { ButtonNewChat } from "@/app/components/layout/button-new-chat"
 import { UserMenu } from "@/app/components/layout/user-menu"
 import { useBreakpoint } from "@/app/hooks/use-breakpoint"
 import { Logo } from "@/components/ui/logo"
-import { ThemeToggle } from "@/components/ui/theme-toggle"
 import { Button } from "@/components/ui/button"
 import { APP_NAME } from "@/lib/config"
 import { useUserPreferences } from "@/lib/user-preference-store/provider"
@@ -52,7 +51,6 @@ export function Header({ hasSidebar }: { hasSidebar: boolean }) {
           <div />
           {!isLoggedIn ? (
             <div className="pointer-events-auto flex flex-1 items-center justify-end gap-3">
-              <ThemeToggle />
               <AppInfoTrigger
                 trigger={
                   <Button
@@ -75,7 +73,6 @@ export function Header({ hasSidebar }: { hasSidebar: boolean }) {
             </div>
           ) : (
             <div className="pointer-events-auto flex flex-1 items-center justify-end gap-2">
-              <ThemeToggle />
               {!isMultiModelEnabled && <DialogPublish />}
               <ButtonNewChat />
               {!hasSidebar && <HistoryTrigger hasSidebar={hasSidebar} />}

--- a/app/components/layout/settings/appearance/theme-selection.tsx
+++ b/app/components/layout/settings/appearance/theme-selection.tsx
@@ -1,14 +1,37 @@
 "use client"
 
+import { ThemeToggle } from "@/components/ui/theme-toggle"
 import { useUserPreferences, type ThemeType } from "@/lib/user-preference-store/provider"
 import { cn } from "@/lib/utils"
 import { useTheme } from "next-themes"
-import { useEffect, useState } from "react"
+import { useEffect, useMemo, useState } from "react"
 
 export function ThemeSelection() {
   const { preferences, setTheme: setUserTheme } = useUserPreferences()
   const { setTheme } = useTheme()
   const [mounted, setMounted] = useState(false)
+
+  const themeHeader = useMemo(
+    () => (
+      <div className="mb-4 flex flex-wrap items-center justify-between gap-3">
+        <div>
+          <h4 className="text-sm font-medium">Theme</h4>
+          <p className="text-xs text-muted-foreground">
+            Choose how Bob looks and feels.
+          </p>
+        </div>
+        {mounted ? (
+          <ThemeToggle className="pointer-events-auto" />
+        ) : (
+          <div
+            className="h-9 w-9 rounded-full bg-muted animate-pulse"
+            aria-hidden="true"
+          />
+        )}
+      </div>
+    ),
+    [mounted]
+  )
 
   // Ensure component is mounted to avoid hydration mismatches
   useEffect(() => {
@@ -50,8 +73,8 @@ export function ThemeSelection() {
 
   if (!mounted) {
     return (
-      <div>
-        <h4 className="mb-3 text-sm font-medium">Theme</h4>
+      <div className="glass-panel p-4">
+        {themeHeader}
         <div className="grid grid-cols-3 gap-3">
           {themes.map((theme) => (
             <div
@@ -76,7 +99,7 @@ export function ThemeSelection() {
 
   return (
     <div className="glass-panel p-4">
-      <h4 className="mb-3 text-sm font-medium">Theme</h4>
+      {themeHeader}
       <div className="space-y-2">
         {themes.map((themeOption) => (
           <label

--- a/lib/providers/app-provider.tsx
+++ b/lib/providers/app-provider.tsx
@@ -36,7 +36,7 @@ export function AppProvider({ children, userProfile }: AppProviderProps) {
                   >
                     <ThemeProvider
                       attribute="class"
-                      defaultTheme="system"
+                      defaultTheme="dark"
                       enableSystem
                       disableTransitionOnChange
                       storageKey="bob-theme"

--- a/lib/user-preference-store/utils.ts
+++ b/lib/user-preference-store/utils.ts
@@ -15,7 +15,7 @@ export type UserPreferences = {
 
 export const defaultPreferences: UserPreferences = {
   layout: "fullscreen",
-  theme: "system",
+  theme: "dark",
   promptSuggestions: true,
   showToolInvocations: true,
   showConversationPreviews: true,


### PR DESCRIPTION
## Summary
- set the default theme preference and Next.js ThemeProvider to dark so new sessions start with the dark palette
- remove the theme toggle from the header and expose it within the Appearance settings alongside the existing theme options

## Testing
- npm run lint *(fails: existing lint errors in unrelated files such as app/components/chat/chat.tsx)*
- npm run type-check *(fails: existing merge conflict marker in app/components/chat/chat.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68d3abe96160832a985af3da8fc4253b