### PR TITLE
Fix: Fix chat input auto-populates with predefined prompts (#46)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,1 @@
+## Issue #46: Fix chat input auto-populates with predefined prompts


### PR DESCRIPTION
Addresses GitHub Issue #46

Fix chat input auto-populates with predefined prompts

Type: bug